### PR TITLE
Feature/scf 807 mmc cache

### DIFF
--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
@@ -624,11 +624,11 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
   * @}
   */
 
-HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable);
-
 /** @defgroup MMC_Exported_Functions_Group3 Peripheral Control functions
   * @{
   */
+HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable);
+HAL_StatusTypeDef HAL_MMC_FlushCache(MMC_HandleTypeDef *hmmc);
 HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32_t WideMode);
 /**
   * @}

--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -144,6 +143,8 @@ typedef struct
   uint32_t                     CSD[4U];          /*!< MMC card specific data table         */
 
   uint32_t                     CID[4U];          /*!< MMC card identification number table */
+
+  uint32_t                     Ext_CSD[128];
 
 #if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
   void (* TxCpltCallback)                 (struct __MMC_HandleTypeDef *hmmc);
@@ -334,10 +335,12 @@ typedef void (*pMMC_CallbackTypeDef)           (MMC_HandleTypeDef *hmmc);
 /**
   * @brief
   */
-#define MMC_HIGH_VOLTAGE_RANGE         0x80FF8000U  /*!< VALUE OF ARGUMENT            */
-#define MMC_DUAL_VOLTAGE_RANGE         0x80FF8080U  /*!< VALUE OF ARGUMENT            */
-#define eMMC_HIGH_VOLTAGE_RANGE        0xC0FF8000U  /*!< for eMMC > 2Gb sector mode   */
-#define eMMC_DUAL_VOLTAGE_RANGE        0xC0FF8080U  /*!< for eMMC > 2Gb sector mode   */
+#define MMC_HIGH_VOLTAGE_RANGE         0x80FF8000U  /*!< High voltage in byte mode    */
+#define MMC_DUAL_VOLTAGE_RANGE         0x80FF8080U  /*!< Dual voltage in byte mode    */
+#define MMC_LOW_VOLTAGE_RANGE          0x80000080U  /*!< Low voltage in byte mode     */
+#define EMMC_HIGH_VOLTAGE_RANGE        0xC0FF8000U  /*!< High voltage in sector mode  */
+#define EMMC_DUAL_VOLTAGE_RANGE        0xC0FF8080U  /*!< Dual voltage in sector mode  */
+#define EMMC_LOW_VOLTAGE_RANGE         0xC0000080U  /*!< Low voltage in sector mode   */
 #define MMC_INVALID_VOLTAGE_RANGE      0x0001FF01U
 /**
   * @}
@@ -621,6 +624,8 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
   * @}
   */
 
+HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable);
+
 /** @defgroup MMC_Exported_Functions_Group3 Peripheral Control functions
   * @{
   */
@@ -636,6 +641,7 @@ HAL_MMC_CardStateTypeDef HAL_MMC_GetCardState(MMC_HandleTypeDef *hmmc);
 HAL_StatusTypeDef HAL_MMC_GetCardCID(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCIDTypeDef *pCID);
 HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTypeDef *pCSD);
 HAL_StatusTypeDef HAL_MMC_GetCardInfo(MMC_HandleTypeDef *hmmc, HAL_MMC_CardInfoTypeDef *pCardInfo);
+HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtCSD, uint32_t Timeout);
 /**
   * @}
   */
@@ -649,7 +655,7 @@ uint32_t HAL_MMC_GetError(MMC_HandleTypeDef *hmmc);
   * @}
   */
 
-/** @defgroup MMC_Exported_Functions_Group6 Perioheral Abort management
+/** @defgroup MMC_Exported_Functions_Group6 Peripheral Abort management
   * @{
   */
 HAL_StatusTypeDef HAL_MMC_Abort(MMC_HandleTypeDef *hmmc);
@@ -741,5 +747,3 @@ HAL_StatusTypeDef HAL_MMC_Abort_IT(MMC_HandleTypeDef *hmmc);
 #endif /* SDMMC1 */
 
 #endif /* STM32F7xx_HAL_MMC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_sdmmc.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_sdmmc.h
@@ -14,7 +14,7 @@
   * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32F7xx_LL_SDMMC_H
@@ -35,15 +35,15 @@
 
 /** @addtogroup SDMMC_LL
   * @{
-  */ 
+  */
 
-/* Exported types ------------------------------------------------------------*/ 
+/* Exported types ------------------------------------------------------------*/
 /** @defgroup SDMMC_LL_Exported_Types SDMMC_LL Exported Types
   * @{
   */
-  
-/** 
-  * @brief  SDMMC Configuration Structure definition  
+
+/**
+  * @brief  SDMMC Configuration Structure definition
   */
 typedef struct
 {
@@ -65,28 +65,28 @@ typedef struct
                                       This parameter can be a value of @ref SDMMC_LL_Hardware_Flow_Control      */
 
   uint32_t ClockDiv;             /*!< Specifies the clock frequency of the SDMMC controller.
-                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */  
-  
-}SDMMC_InitTypeDef;
-  
+                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */
 
-/** 
-  * @brief  SDMMC Command Control structure 
+}SDMMC_InitTypeDef;
+
+
+/**
+  * @brief  SDMMC Command Control structure
   */
-typedef struct                                                                                            
+typedef struct
 {
   uint32_t Argument;            /*!< Specifies the SDMMC command argument which is sent
                                      to a card as part of a command message. If a command
                                      contains an argument, it must be loaded into this register
                                      before writing the command to the command register.              */
 
-  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and 
+  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and
                                      Max_Data = 64                                                    */
 
   uint32_t Response;            /*!< Specifies the SDMMC response type.
                                      This parameter can be a value of @ref SDMMC_LL_Response_Type         */
 
-  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is 
+  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is
                                      enabled or disabled.
                                      This parameter can be a value of @ref SDMMC_LL_Wait_Interrupt_State  */
 
@@ -96,25 +96,25 @@ typedef struct
 }SDMMC_CmdInitTypeDef;
 
 
-/** 
-  * @brief  SDMMC Data Control structure 
+/**
+  * @brief  SDMMC Data Control structure
   */
 typedef struct
 {
   uint32_t DataTimeOut;         /*!< Specifies the data timeout period in card bus clock periods.  */
 
   uint32_t DataLength;          /*!< Specifies the number of data bytes to be transferred.         */
- 
+
   uint32_t DataBlockSize;       /*!< Specifies the data block size for block transfer.
                                      This parameter can be a value of @ref SDMMC_LL_Data_Block_Size    */
- 
+
   uint32_t TransferDir;         /*!< Specifies the data transfer direction, whether the transfer
                                      is a read or write.
                                      This parameter can be a value of @ref SDMMC_LL_Transfer_Direction */
- 
+
   uint32_t TransferMode;        /*!< Specifies whether data transfer is in stream or block mode.
                                      This parameter can be a value of @ref SDMMC_LL_Transfer_Type      */
- 
+
   uint32_t DPSM;                /*!< Specifies whether SDMMC Data path state machine (DPSM)
                                      is enabled or disabled.
                                      This parameter can be a value of @ref SDMMC_LL_DPSM_State         */
@@ -123,7 +123,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup SDMMC_LL_Exported_Constants SDMMC_LL Exported Constants
   * @{
@@ -165,8 +165,8 @@ typedef struct
 #define SDMMC_ERROR_DMA                                 0x40000000U    /*!< Error while DMA transfer                                      */
 #define SDMMC_ERROR_TIMEOUT                             0x80000000U    /*!< Timeout error                                                 */
 
-/** 
-  * @brief SDMMC Commands Index 
+/**
+  * @brief SDMMC Commands Index
   */
 #define SDMMC_CMD_GO_IDLE_STATE                                 0U    /*!< Resets the SD memory card.                                                               */
 #define SDMMC_CMD_SEND_OP_COND                                  1U    /*!< Sends host capacity support information and activates the card's initialization process. */
@@ -187,7 +187,7 @@ typedef struct
 #define SDMMC_CMD_HS_BUSTEST_READ                               14U   /*!< Reserved                                                                                 */
 #define SDMMC_CMD_GO_INACTIVE_STATE                             15U   /*!< Sends an addressed card into the inactive state.                                         */
 #define SDMMC_CMD_SET_BLOCKLEN                                  16U   /*!< Sets the block length (in bytes for SDSC) for all following block commands
-                                                                           (read, write, lock). Default block length is fixed to 512 Bytes. Not effective 
+                                                                           (read, write, lock). Default block length is fixed to 512 Bytes. Not effective
                                                                            for SDHS and SDXC.                                                                       */
 #define SDMMC_CMD_READ_SINGLE_BLOCK                             17U   /*!< Reads single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of
                                                                            fixed 512 bytes in case of SDHC and SDXC.                                                */
@@ -221,9 +221,9 @@ typedef struct
                                                                            for general purpose/application specific commands.                                       */
 #define SDMMC_CMD_NO_CMD                                        64U   /*!< No command                                                                               */
 
-/** 
+/**
   * @brief Following commands are SD Card Specific commands.
-  *        SDMMC_APP_CMD should be sent before sending these commands. 
+  *        SDMMC_APP_CMD should be sent before sending these commands.
   */
 #define SDMMC_CMD_APP_SD_SET_BUSWIDTH                           6U    /*!< (ACMD6) Defines the data bus width to be used for data transfer. The allowed data bus
                                                                             widths are given in SCR register.                                                       */
@@ -237,9 +237,9 @@ typedef struct
 #define SDMMC_CMD_SDMMC_RW_DIRECT                               52U   /*!< For SD I/O card only, reserved for security specification.                               */
 #define SDMMC_CMD_SDMMC_RW_EXTENDED                             53U   /*!< For SD I/O card only, reserved for security specification.                               */
 
-/** 
+/**
   * @brief Following commands are SD Card Specific security commands.
-  *        SDMMC_CMD_APP_CMD should be sent before sending these commands. 
+  *        SDMMC_CMD_APP_CMD should be sent before sending these commands.
   */
 #define SDMMC_CMD_SD_APP_GET_MKB                                43U
 #define SDMMC_CMD_SD_APP_GET_MID                                44U
@@ -253,8 +253,8 @@ typedef struct
 #define SDMMC_CMD_SD_APP_CHANGE_SECURE_AREA                     49U
 #define SDMMC_CMD_SD_APP_SECURE_WRITE_MKB                       48U
 
-/** 
-  * @brief  Masks for errors Card Status R1 (OCR Register) 
+/**
+  * @brief  Masks for errors Card Status R1 (OCR Register)
   */
 #define SDMMC_OCR_ADDR_OUT_OF_RANGE                   0x80000000U
 #define SDMMC_OCR_ADDR_MISALIGNED                     0x40000000U
@@ -277,8 +277,8 @@ typedef struct
 #define SDMMC_OCR_AKE_SEQ_ERROR                       0x00000008U
 #define SDMMC_OCR_ERRORBITS                           0xFDFFE008U
 
-/** 
-  * @brief  Masks for R6 Response 
+/**
+  * @brief  Masks for R6 Response
   */
 #define SDMMC_R6_GENERAL_UNKNOWN_ERROR                0x00002000U
 #define SDMMC_R6_ILLEGAL_CMD                          0x00004000U
@@ -313,7 +313,7 @@ typedef struct
 #define SDMMC_HALFFIFO                                0x00000008U
 #define SDMMC_HALFFIFOBYTES                           0x00000020U
 
-/** 
+/**
   * @brief  Command Class supported
   */
 #define SDMMC_CCCC_ERASE                       0x00000020U
@@ -338,13 +338,13 @@ typedef struct
   * @{
   */
 #define SDMMC_CLOCK_BYPASS_DISABLE             0x00000000U
-#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS   
+#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS
 
 #define IS_SDMMC_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDMMC_CLOCK_BYPASS_DISABLE) || \
                                               ((BYPASS) == SDMMC_CLOCK_BYPASS_ENABLE))
 /**
   * @}
-  */ 
+  */
 
 /** @defgroup SDMMC_LL_Clock_Power_Save Clock Power Saving
   * @{
@@ -383,15 +383,15 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @defgroup SDMMC_LL_Clock_Division Clock Division
   * @{
   */
 #define IS_SDMMC_CLKDIV(DIV)   ((DIV) <= 0xFFU)
 /**
   * @}
-  */  
-    
+  */
+
 /** @defgroup SDMMC_LL_Command_Index Command Index
   * @{
   */
@@ -418,7 +418,7 @@ typedef struct
   * @{
   */
 #define SDMMC_WAIT_NO                        0x00000000U
-#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT 
+#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT
 #define SDMMC_WAIT_PEND                      SDMMC_CMD_WAITPEND
 
 #define IS_SDMMC_WAIT(WAIT) (((WAIT) == SDMMC_WAIT_NO) || \
@@ -438,7 +438,7 @@ typedef struct
                                     ((CPSM) == SDMMC_CPSM_ENABLE))
 /**
   * @}
-  */  
+  */
 
 /** @defgroup SDMMC_LL_Response_Registers Response Register
   * @{
@@ -478,7 +478,7 @@ typedef struct
 #define SDMMC_DATABLOCK_SIZE_256B             SDMMC_DCTRL_DBLOCKSIZE_3
 #define SDMMC_DATABLOCK_SIZE_512B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_1024B            (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
-#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3) 
+#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_4096B            (SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_8192B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_16384B           (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
@@ -497,7 +497,7 @@ typedef struct
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_2048B) || \
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_4096B) || \
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_8192B) || \
-                                          ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B)) 
+                                          ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B))
 /**
   * @}
   */
@@ -537,7 +537,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /** @defgroup SDMMC_LL_Read_Wait_Mode Read Wait Mode
   * @{
   */
@@ -548,7 +548,7 @@ typedef struct
                                              ((MODE) == SDMMC_READ_WAIT_MODE_DATA2))
 /**
   * @}
-  */  
+  */
 
 /** @defgroup SDMMC_LL_Interrupt_sources Interrupt Sources
   * @{
@@ -577,7 +577,7 @@ typedef struct
 #define SDMMC_IT_SDIOIT                      SDMMC_MASK_SDIOITIE
 /**
   * @}
-  */ 
+  */
 
 /** @defgroup SDMMC_LL_Flags Flags
   * @{
@@ -607,7 +607,7 @@ typedef struct
 #define SDMMC_STATIC_FLAGS                   ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_CTIMEOUT |\
                                                          SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_RXOVERR  |\
                                                          SDMMC_FLAG_CMDREND  | SDMMC_FLAG_CMDSENT  | SDMMC_FLAG_DATAEND  |\
-                                                         SDMMC_FLAG_DBCKEND | SDMMC_FLAG_SDIOIT))  
+                                                         SDMMC_FLAG_DBCKEND | SDMMC_FLAG_SDIOIT))
 
 #define SDMMC_STATIC_CMD_FLAGS               ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CTIMEOUT | SDMMC_FLAG_CMDREND |\
                                                          SDMMC_FLAG_CMDSENT))
@@ -621,7 +621,7 @@ typedef struct
 /**
   * @}
   */
-  
+
 /* Exported macro ------------------------------------------------------------*/
 /** @defgroup SDMMC_LL_Exported_macros SDMMC_LL Exported Macros
   * @{
@@ -633,7 +633,7 @@ typedef struct
   */
 /* ---------------------- SDMMC registers bit mask --------------------------- */
 /* --- CLKCR Register ---*/
-/* CLKCR register clear mask */ 
+/* CLKCR register clear mask */
 #define CLKCR_CLEAR_MASK         ((uint32_t)(SDMMC_CLKCR_CLKDIV  | SDMMC_CLKCR_PWRSAV |\
                                              SDMMC_CLKCR_BYPASS  | SDMMC_CLKCR_WIDBUS |\
                                              SDMMC_CLKCR_NEGEDGE | SDMMC_CLKCR_HWFC_EN))
@@ -662,38 +662,38 @@ typedef struct
  *  @brief macros to handle interrupts and specific clock configurations
  * @{
  */
- 
+
 /**
   * @brief  Enable the SDMMC device.
-  * @param  __INSTANCE__: SDMMC Instance  
+  * @param  __INSTANCE__: SDMMC Instance
   * @retval None
   */
 #define __SDMMC_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR |= SDMMC_CLKCR_CLKEN)
 
 /**
   * @brief  Disable the SDMMC device.
-  * @param  __INSTANCE__: SDMMC Instance  
+  * @param  __INSTANCE__: SDMMC Instance
   * @retval None
   */
 #define __SDMMC_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR &= ~SDMMC_CLKCR_CLKEN)
 
 /**
   * @brief  Enable the SDMMC DMA transfer.
-  * @param  __INSTANCE__: SDMMC Instance  
+  * @param  __INSTANCE__: SDMMC Instance
   * @retval None
   */
 #define __SDMMC_DMA_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_DMAEN)
 
 /**
   * @brief  Disable the SDMMC DMA transfer.
-  * @param  __INSTANCE__: SDMMC Instance   
+  * @param  __INSTANCE__: SDMMC Instance
   * @retval None
   */
 #define __SDMMC_DMA_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_DMAEN)
- 
+
 /**
   * @brief  Enable the SDMMC device interrupt.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be enabled.
   *         This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
@@ -717,14 +717,14 @@ typedef struct
   *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
   *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
   *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
-  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt 
+  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt
   * @retval None
   */
 #define __SDMMC_ENABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK |= (__INTERRUPT__))
 
 /**
   * @brief  Disable the SDMMC device interrupt.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be disabled.
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
@@ -748,15 +748,15 @@ typedef struct
   *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
   *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
   *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
-  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt   
+  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt
   * @retval None
   */
 #define __SDMMC_DISABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Checks whether the specified SDMMC flag is set or not. 
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
-  * @param  __FLAG__: specifies the flag to check. 
+  * @brief  Checks whether the specified SDMMC flag is set or not.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __FLAG__: specifies the flag to check.
   *          This parameter can be one of the following values:
   *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
   *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
@@ -787,8 +787,8 @@ typedef struct
 
 /**
   * @brief  Clears the SDMMC pending flags.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
-  * @param  __FLAG__: specifies the flag to clear.  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __FLAG__: specifies the flag to clear.
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
   *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
@@ -807,8 +807,8 @@ typedef struct
 
 /**
   * @brief  Checks whether the specified SDMMC interrupt has occurred or not.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
-  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check. 
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check.
   *          This parameter can be one of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
   *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
@@ -838,8 +838,8 @@ typedef struct
 
 /**
   * @brief  Clears the SDMMC's interrupt pending bits.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base 
-  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. 
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
   *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
@@ -857,59 +857,59 @@ typedef struct
 
 /**
   * @brief  Enable Start the SD I/O Read Wait operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
 #define __SDMMC_START_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTART)
 
 /**
   * @brief  Disable Start the SD I/O Read Wait operations.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
 #define __SDMMC_START_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTART)
 
 /**
   * @brief  Enable Start the SD I/O Read Wait operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
 #define __SDMMC_STOP_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTOP)
 
 /**
   * @brief  Disable Stop the SD I/O Read Wait operations.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
 #define __SDMMC_STOP_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTOP)
 
 /**
   * @brief  Enable the SD I/O Mode Operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
 #define __SDMMC_OPERATION_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_SDIOEN)
 
 /**
   * @brief  Disable the SD I/O Mode Operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base 
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
-#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN) 
+#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN)
 
 /**
   * @brief  Enable the SD I/O Suspend command sending.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
-#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND) 
+#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND)
 
 /**
   * @brief  Disable the SD I/O Suspend command sending.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __INSTANCE__ : Pointer to SDMMC register base
   * @retval None
   */
-#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND) 
+#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND)
 
 /**
   * @}
@@ -917,13 +917,13 @@ typedef struct
 
 /**
   * @}
-  */  
+  */
 
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup SDMMC_LL_Exported_Functions
   * @{
   */
-  
+
 /* Initialization/de-initialization functions  **********************************/
 /** @addtogroup HAL_SDMMC_LL_Group1
   * @{
@@ -932,7 +932,7 @@ HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init);
 /**
   * @}
   */
-  
+
 /* I/O operation functions  *****************************************************/
 /** @addtogroup HAL_SDMMC_LL_Group2
   * @{
@@ -942,7 +942,7 @@ HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData);
 /**
   * @}
   */
-  
+
 /* Peripheral Control functions  ************************************************/
 /** @addtogroup HAL_SDMMC_LL_Group3
   * @{
@@ -991,6 +991,7 @@ uint32_t SDMMC_CmdBusWidth(SDMMC_TypeDef *SDMMCx, uint32_t BusWidth);
 uint32_t SDMMC_CmdSendSCR(SDMMC_TypeDef *SDMMCx);
 uint32_t SDMMC_CmdSendCID(SDMMC_TypeDef *SDMMCx);
 uint32_t SDMMC_CmdSendCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
+uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
 uint32_t SDMMC_CmdSetRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA);
 uint32_t SDMMC_CmdSetRelAddMmc(SDMMC_TypeDef *SDMMCx, uint16_t RCA);
 uint32_t SDMMC_CmdSendStatus(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
@@ -1014,14 +1015,14 @@ uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx);
 /**
   * @}
   */
-  
+
 /**
   * @}
   */
-  
+
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}

--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_sdmmc.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_ll_sdmmc.h
@@ -6,16 +6,15 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */
+  */ 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32F7xx_LL_SDMMC_H
@@ -36,15 +35,15 @@
 
 /** @addtogroup SDMMC_LL
   * @{
-  */
+  */ 
 
-/* Exported types ------------------------------------------------------------*/
+/* Exported types ------------------------------------------------------------*/ 
 /** @defgroup SDMMC_LL_Exported_Types SDMMC_LL Exported Types
   * @{
   */
-
-/**
-  * @brief  SDMMC Configuration Structure definition
+  
+/** 
+  * @brief  SDMMC Configuration Structure definition  
   */
 typedef struct
 {
@@ -66,28 +65,28 @@ typedef struct
                                       This parameter can be a value of @ref SDMMC_LL_Hardware_Flow_Control      */
 
   uint32_t ClockDiv;             /*!< Specifies the clock frequency of the SDMMC controller.
-                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */
-
+                                      This parameter can be a value between Min_Data = 0 and Max_Data = 255 */  
+  
 }SDMMC_InitTypeDef;
+  
 
-
-/**
-  * @brief  SDMMC Command Control structure
+/** 
+  * @brief  SDMMC Command Control structure 
   */
-typedef struct
+typedef struct                                                                                            
 {
   uint32_t Argument;            /*!< Specifies the SDMMC command argument which is sent
                                      to a card as part of a command message. If a command
                                      contains an argument, it must be loaded into this register
                                      before writing the command to the command register.              */
 
-  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and
+  uint32_t CmdIndex;            /*!< Specifies the SDMMC command index. It must be Min_Data = 0 and 
                                      Max_Data = 64                                                    */
 
   uint32_t Response;            /*!< Specifies the SDMMC response type.
                                      This parameter can be a value of @ref SDMMC_LL_Response_Type         */
 
-  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is
+  uint32_t WaitForInterrupt;    /*!< Specifies whether SDMMC wait for interrupt request is 
                                      enabled or disabled.
                                      This parameter can be a value of @ref SDMMC_LL_Wait_Interrupt_State  */
 
@@ -97,25 +96,25 @@ typedef struct
 }SDMMC_CmdInitTypeDef;
 
 
-/**
-  * @brief  SDMMC Data Control structure
+/** 
+  * @brief  SDMMC Data Control structure 
   */
 typedef struct
 {
   uint32_t DataTimeOut;         /*!< Specifies the data timeout period in card bus clock periods.  */
 
   uint32_t DataLength;          /*!< Specifies the number of data bytes to be transferred.         */
-
+ 
   uint32_t DataBlockSize;       /*!< Specifies the data block size for block transfer.
                                      This parameter can be a value of @ref SDMMC_LL_Data_Block_Size    */
-
+ 
   uint32_t TransferDir;         /*!< Specifies the data transfer direction, whether the transfer
                                      is a read or write.
                                      This parameter can be a value of @ref SDMMC_LL_Transfer_Direction */
-
+ 
   uint32_t TransferMode;        /*!< Specifies whether data transfer is in stream or block mode.
                                      This parameter can be a value of @ref SDMMC_LL_Transfer_Type      */
-
+ 
   uint32_t DPSM;                /*!< Specifies whether SDMMC Data path state machine (DPSM)
                                      is enabled or disabled.
                                      This parameter can be a value of @ref SDMMC_LL_DPSM_State         */
@@ -124,7 +123,7 @@ typedef struct
 /**
   * @}
   */
-
+  
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup SDMMC_LL_Exported_Constants SDMMC_LL Exported Constants
   * @{
@@ -166,8 +165,8 @@ typedef struct
 #define SDMMC_ERROR_DMA                                 0x40000000U    /*!< Error while DMA transfer                                      */
 #define SDMMC_ERROR_TIMEOUT                             0x80000000U    /*!< Timeout error                                                 */
 
-/**
-  * @brief SDMMC Commands Index
+/** 
+  * @brief SDMMC Commands Index 
   */
 #define SDMMC_CMD_GO_IDLE_STATE                                 0U    /*!< Resets the SD memory card.                                                               */
 #define SDMMC_CMD_SEND_OP_COND                                  1U    /*!< Sends host capacity support information and activates the card's initialization process. */
@@ -188,7 +187,7 @@ typedef struct
 #define SDMMC_CMD_HS_BUSTEST_READ                               14U   /*!< Reserved                                                                                 */
 #define SDMMC_CMD_GO_INACTIVE_STATE                             15U   /*!< Sends an addressed card into the inactive state.                                         */
 #define SDMMC_CMD_SET_BLOCKLEN                                  16U   /*!< Sets the block length (in bytes for SDSC) for all following block commands
-                                                                           (read, write, lock). Default block length is fixed to 512 Bytes. Not effective
+                                                                           (read, write, lock). Default block length is fixed to 512 Bytes. Not effective 
                                                                            for SDHS and SDXC.                                                                       */
 #define SDMMC_CMD_READ_SINGLE_BLOCK                             17U   /*!< Reads single block of size selected by SET_BLOCKLEN in case of SDSC, and a block of
                                                                            fixed 512 bytes in case of SDHC and SDXC.                                                */
@@ -222,9 +221,9 @@ typedef struct
                                                                            for general purpose/application specific commands.                                       */
 #define SDMMC_CMD_NO_CMD                                        64U   /*!< No command                                                                               */
 
-/**
+/** 
   * @brief Following commands are SD Card Specific commands.
-  *        SDMMC_APP_CMD should be sent before sending these commands.
+  *        SDMMC_APP_CMD should be sent before sending these commands. 
   */
 #define SDMMC_CMD_APP_SD_SET_BUSWIDTH                           6U    /*!< (ACMD6) Defines the data bus width to be used for data transfer. The allowed data bus
                                                                             widths are given in SCR register.                                                       */
@@ -238,9 +237,9 @@ typedef struct
 #define SDMMC_CMD_SDMMC_RW_DIRECT                               52U   /*!< For SD I/O card only, reserved for security specification.                               */
 #define SDMMC_CMD_SDMMC_RW_EXTENDED                             53U   /*!< For SD I/O card only, reserved for security specification.                               */
 
-/**
+/** 
   * @brief Following commands are SD Card Specific security commands.
-  *        SDMMC_CMD_APP_CMD should be sent before sending these commands.
+  *        SDMMC_CMD_APP_CMD should be sent before sending these commands. 
   */
 #define SDMMC_CMD_SD_APP_GET_MKB                                43U
 #define SDMMC_CMD_SD_APP_GET_MID                                44U
@@ -254,8 +253,8 @@ typedef struct
 #define SDMMC_CMD_SD_APP_CHANGE_SECURE_AREA                     49U
 #define SDMMC_CMD_SD_APP_SECURE_WRITE_MKB                       48U
 
-/**
-  * @brief  Masks for errors Card Status R1 (OCR Register)
+/** 
+  * @brief  Masks for errors Card Status R1 (OCR Register) 
   */
 #define SDMMC_OCR_ADDR_OUT_OF_RANGE                   0x80000000U
 #define SDMMC_OCR_ADDR_MISALIGNED                     0x40000000U
@@ -278,8 +277,8 @@ typedef struct
 #define SDMMC_OCR_AKE_SEQ_ERROR                       0x00000008U
 #define SDMMC_OCR_ERRORBITS                           0xFDFFE008U
 
-/**
-  * @brief  Masks for R6 Response
+/** 
+  * @brief  Masks for R6 Response 
   */
 #define SDMMC_R6_GENERAL_UNKNOWN_ERROR                0x00002000U
 #define SDMMC_R6_ILLEGAL_CMD                          0x00004000U
@@ -314,7 +313,7 @@ typedef struct
 #define SDMMC_HALFFIFO                                0x00000008U
 #define SDMMC_HALFFIFOBYTES                           0x00000020U
 
-/**
+/** 
   * @brief  Command Class supported
   */
 #define SDMMC_CCCC_ERASE                       0x00000020U
@@ -339,13 +338,13 @@ typedef struct
   * @{
   */
 #define SDMMC_CLOCK_BYPASS_DISABLE             0x00000000U
-#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS
+#define SDMMC_CLOCK_BYPASS_ENABLE              SDMMC_CLKCR_BYPASS   
 
 #define IS_SDMMC_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDMMC_CLOCK_BYPASS_DISABLE) || \
                                               ((BYPASS) == SDMMC_CLOCK_BYPASS_ENABLE))
 /**
   * @}
-  */
+  */ 
 
 /** @defgroup SDMMC_LL_Clock_Power_Save Clock Power Saving
   * @{
@@ -384,15 +383,15 @@ typedef struct
 /**
   * @}
   */
-
+  
 /** @defgroup SDMMC_LL_Clock_Division Clock Division
   * @{
   */
 #define IS_SDMMC_CLKDIV(DIV)   ((DIV) <= 0xFFU)
 /**
   * @}
-  */
-
+  */  
+    
 /** @defgroup SDMMC_LL_Command_Index Command Index
   * @{
   */
@@ -419,7 +418,7 @@ typedef struct
   * @{
   */
 #define SDMMC_WAIT_NO                        0x00000000U
-#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT
+#define SDMMC_WAIT_IT                        SDMMC_CMD_WAITINT 
 #define SDMMC_WAIT_PEND                      SDMMC_CMD_WAITPEND
 
 #define IS_SDMMC_WAIT(WAIT) (((WAIT) == SDMMC_WAIT_NO) || \
@@ -439,7 +438,7 @@ typedef struct
                                     ((CPSM) == SDMMC_CPSM_ENABLE))
 /**
   * @}
-  */
+  */  
 
 /** @defgroup SDMMC_LL_Response_Registers Response Register
   * @{
@@ -479,7 +478,7 @@ typedef struct
 #define SDMMC_DATABLOCK_SIZE_256B             SDMMC_DCTRL_DBLOCKSIZE_3
 #define SDMMC_DATABLOCK_SIZE_512B             (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_1024B            (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
-#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3)
+#define SDMMC_DATABLOCK_SIZE_2048B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_3) 
 #define SDMMC_DATABLOCK_SIZE_4096B            (SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_8192B            (SDMMC_DCTRL_DBLOCKSIZE_0|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
 #define SDMMC_DATABLOCK_SIZE_16384B           (SDMMC_DCTRL_DBLOCKSIZE_1|SDMMC_DCTRL_DBLOCKSIZE_2|SDMMC_DCTRL_DBLOCKSIZE_3)
@@ -498,7 +497,7 @@ typedef struct
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_2048B) || \
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_4096B) || \
                                           ((SIZE) == SDMMC_DATABLOCK_SIZE_8192B) || \
-                                          ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B))
+                                          ((SIZE) == SDMMC_DATABLOCK_SIZE_16384B)) 
 /**
   * @}
   */
@@ -538,7 +537,7 @@ typedef struct
 /**
   * @}
   */
-
+  
 /** @defgroup SDMMC_LL_Read_Wait_Mode Read Wait Mode
   * @{
   */
@@ -549,7 +548,7 @@ typedef struct
                                              ((MODE) == SDMMC_READ_WAIT_MODE_DATA2))
 /**
   * @}
-  */
+  */  
 
 /** @defgroup SDMMC_LL_Interrupt_sources Interrupt Sources
   * @{
@@ -578,7 +577,7 @@ typedef struct
 #define SDMMC_IT_SDIOIT                      SDMMC_MASK_SDIOITIE
 /**
   * @}
-  */
+  */ 
 
 /** @defgroup SDMMC_LL_Flags Flags
   * @{
@@ -608,7 +607,7 @@ typedef struct
 #define SDMMC_STATIC_FLAGS                   ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_CTIMEOUT |\
                                                          SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_RXOVERR  |\
                                                          SDMMC_FLAG_CMDREND  | SDMMC_FLAG_CMDSENT  | SDMMC_FLAG_DATAEND  |\
-                                                         SDMMC_FLAG_DBCKEND | SDMMC_FLAG_SDIOIT))
+                                                         SDMMC_FLAG_DBCKEND | SDMMC_FLAG_SDIOIT))  
 
 #define SDMMC_STATIC_CMD_FLAGS               ((uint32_t)(SDMMC_FLAG_CCRCFAIL | SDMMC_FLAG_CTIMEOUT | SDMMC_FLAG_CMDREND |\
                                                          SDMMC_FLAG_CMDSENT))
@@ -622,7 +621,7 @@ typedef struct
 /**
   * @}
   */
-
+  
 /* Exported macro ------------------------------------------------------------*/
 /** @defgroup SDMMC_LL_Exported_macros SDMMC_LL Exported Macros
   * @{
@@ -634,7 +633,7 @@ typedef struct
   */
 /* ---------------------- SDMMC registers bit mask --------------------------- */
 /* --- CLKCR Register ---*/
-/* CLKCR register clear mask */
+/* CLKCR register clear mask */ 
 #define CLKCR_CLEAR_MASK         ((uint32_t)(SDMMC_CLKCR_CLKDIV  | SDMMC_CLKCR_PWRSAV |\
                                              SDMMC_CLKCR_BYPASS  | SDMMC_CLKCR_WIDBUS |\
                                              SDMMC_CLKCR_NEGEDGE | SDMMC_CLKCR_HWFC_EN))
@@ -663,38 +662,38 @@ typedef struct
  *  @brief macros to handle interrupts and specific clock configurations
  * @{
  */
-
+ 
 /**
   * @brief  Enable the SDMMC device.
-  * @param  __INSTANCE__: SDMMC Instance
+  * @param  __INSTANCE__: SDMMC Instance  
   * @retval None
   */
 #define __SDMMC_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR |= SDMMC_CLKCR_CLKEN)
 
 /**
   * @brief  Disable the SDMMC device.
-  * @param  __INSTANCE__: SDMMC Instance
+  * @param  __INSTANCE__: SDMMC Instance  
   * @retval None
   */
 #define __SDMMC_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CLKCR &= ~SDMMC_CLKCR_CLKEN)
 
 /**
   * @brief  Enable the SDMMC DMA transfer.
-  * @param  __INSTANCE__: SDMMC Instance
+  * @param  __INSTANCE__: SDMMC Instance  
   * @retval None
   */
 #define __SDMMC_DMA_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_DMAEN)
 
 /**
   * @brief  Disable the SDMMC DMA transfer.
-  * @param  __INSTANCE__: SDMMC Instance
+  * @param  __INSTANCE__: SDMMC Instance   
   * @retval None
   */
 #define __SDMMC_DMA_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_DMAEN)
-
+ 
 /**
   * @brief  Enable the SDMMC device interrupt.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
   * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be enabled.
   *         This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
@@ -718,14 +717,14 @@ typedef struct
   *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
   *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
   *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
-  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt 
   * @retval None
   */
 #define __SDMMC_ENABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK |= (__INTERRUPT__))
 
 /**
   * @brief  Disable the SDMMC device interrupt.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
   * @param  __INTERRUPT__ : specifies the SDMMC interrupt sources to be disabled.
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
@@ -749,15 +748,15 @@ typedef struct
   *            @arg SDMMC_IT_RXFIFOE:  Receive FIFO empty interrupt
   *            @arg SDMMC_IT_TXDAVL:   Data available in transmit FIFO interrupt
   *            @arg SDMMC_IT_RXDAVL:   Data available in receive FIFO interrupt
-  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt
+  *            @arg SDMMC_IT_SDIOIT:   SDIO interrupt received interrupt   
   * @retval None
   */
 #define __SDMMC_DISABLE_IT(__INSTANCE__, __INTERRUPT__)  ((__INSTANCE__)->MASK &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Checks whether the specified SDMMC flag is set or not.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
-  * @param  __FLAG__: specifies the flag to check.
+  * @brief  Checks whether the specified SDMMC flag is set or not. 
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __FLAG__: specifies the flag to check. 
   *          This parameter can be one of the following values:
   *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
   *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
@@ -788,8 +787,8 @@ typedef struct
 
 /**
   * @brief  Clears the SDMMC pending flags.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
-  * @param  __FLAG__: specifies the flag to clear.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
+  * @param  __FLAG__: specifies the flag to clear.  
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_FLAG_CCRCFAIL: Command response received (CRC check failed)
   *            @arg SDMMC_FLAG_DCRCFAIL: Data block sent/received (CRC check failed)
@@ -808,8 +807,8 @@ typedef struct
 
 /**
   * @brief  Checks whether the specified SDMMC interrupt has occurred or not.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
-  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
+  * @param  __INTERRUPT__: specifies the SDMMC interrupt source to check. 
   *          This parameter can be one of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
   *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
@@ -839,8 +838,8 @@ typedef struct
 
 /**
   * @brief  Clears the SDMMC's interrupt pending bits.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
-  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear.
+  * @param  __INSTANCE__ : Pointer to SDMMC register base 
+  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. 
   *          This parameter can be one or a combination of the following values:
   *            @arg SDMMC_IT_CCRCFAIL: Command response received (CRC check failed) interrupt
   *            @arg SDMMC_IT_DCRCFAIL: Data block sent/received (CRC check failed) interrupt
@@ -858,59 +857,59 @@ typedef struct
 
 /**
   * @brief  Enable Start the SD I/O Read Wait operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
   * @retval None
   */
 #define __SDMMC_START_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTART)
 
 /**
   * @brief  Disable Start the SD I/O Read Wait operations.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
   * @retval None
   */
 #define __SDMMC_START_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTART)
 
 /**
   * @brief  Enable Start the SD I/O Read Wait operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
   * @retval None
   */
 #define __SDMMC_STOP_READWAIT_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_RWSTOP)
 
 /**
   * @brief  Disable Stop the SD I/O Read Wait operations.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
   * @retval None
   */
 #define __SDMMC_STOP_READWAIT_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_RWSTOP)
 
 /**
   * @brief  Enable the SD I/O Mode Operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base   
   * @retval None
   */
 #define __SDMMC_OPERATION_ENABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL |= SDMMC_DCTRL_SDIOEN)
 
 /**
   * @brief  Disable the SD I/O Mode Operation.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base 
   * @retval None
   */
-#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN)
+#define __SDMMC_OPERATION_DISABLE(__INSTANCE__)  ((__INSTANCE__)->DCTRL &= ~SDMMC_DCTRL_SDIOEN) 
 
 /**
   * @brief  Enable the SD I/O Suspend command sending.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
   * @retval None
   */
-#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND)
+#define __SDMMC_SUSPEND_CMD_ENABLE(__INSTANCE__)  ((__INSTANCE__)->CMD |= SDMMC_CMD_SDIOSUSPEND) 
 
 /**
   * @brief  Disable the SD I/O Suspend command sending.
-  * @param  __INSTANCE__ : Pointer to SDMMC register base
+  * @param  __INSTANCE__ : Pointer to SDMMC register base  
   * @retval None
   */
-#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND)
+#define __SDMMC_SUSPEND_CMD_DISABLE(__INSTANCE__)  ((__INSTANCE__)->CMD &= ~SDMMC_CMD_SDIOSUSPEND) 
 
 /**
   * @}
@@ -918,13 +917,13 @@ typedef struct
 
 /**
   * @}
-  */
+  */  
 
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup SDMMC_LL_Exported_Functions
   * @{
   */
-
+  
 /* Initialization/de-initialization functions  **********************************/
 /** @addtogroup HAL_SDMMC_LL_Group1
   * @{
@@ -933,7 +932,7 @@ HAL_StatusTypeDef SDMMC_Init(SDMMC_TypeDef *SDMMCx, SDMMC_InitTypeDef Init);
 /**
   * @}
   */
-
+  
 /* I/O operation functions  *****************************************************/
 /** @addtogroup HAL_SDMMC_LL_Group2
   * @{
@@ -943,7 +942,7 @@ HAL_StatusTypeDef SDMMC_WriteFIFO(SDMMC_TypeDef *SDMMCx, uint32_t *pWriteData);
 /**
   * @}
   */
-
+  
 /* Peripheral Control functions  ************************************************/
 /** @addtogroup HAL_SDMMC_LL_Group3
   * @{
@@ -964,8 +963,14 @@ uint32_t          SDMMC_GetFIFOCount(SDMMC_TypeDef *SDMMCx);
 
 /* SDMMC Cards mode management functions */
 HAL_StatusTypeDef SDMMC_SetSDMMCReadWaitMode(SDMMC_TypeDef *SDMMCx, uint32_t SDMMC_ReadWaitMode);
+/**
+  * @}
+  */
 
 /* SDMMC Commands management functions */
+/** @addtogroup HAL_SDMMC_LL_Group4
+  * @{
+  */
 uint32_t SDMMC_CmdBlockLength(SDMMC_TypeDef *SDMMCx, uint32_t BlockSize);
 uint32_t SDMMC_CmdReadSingleBlock(SDMMC_TypeDef *SDMMCx, uint32_t ReadAdd);
 uint32_t SDMMC_CmdReadMultiBlock(SDMMC_TypeDef *SDMMCx, uint32_t ReadAdd);
@@ -986,25 +991,37 @@ uint32_t SDMMC_CmdBusWidth(SDMMC_TypeDef *SDMMCx, uint32_t BusWidth);
 uint32_t SDMMC_CmdSendSCR(SDMMC_TypeDef *SDMMCx);
 uint32_t SDMMC_CmdSendCID(SDMMC_TypeDef *SDMMCx);
 uint32_t SDMMC_CmdSendCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
-uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
-uint32_t SDMMC_CmdSetRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t RCA);
-uint32_t SDMMC_CmdSendRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA);
+uint32_t SDMMC_CmdSetRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA);
+uint32_t SDMMC_CmdSetRelAddMmc(SDMMC_TypeDef *SDMMCx, uint16_t RCA);
 uint32_t SDMMC_CmdSendStatus(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
 uint32_t SDMMC_CmdStatusRegister(SDMMC_TypeDef *SDMMCx);
 uint32_t SDMMC_CmdOpCondition(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
 uint32_t SDMMC_CmdSwitch(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
-
+uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
 /**
   * @}
   */
 
+/* SDMMC Responses management functions *****************************************/
+/** @addtogroup HAL_SDMMC_LL_Group5
+  * @{
+  */
+uint32_t SDMMC_GetCmdResp1(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint32_t Timeout);
+uint32_t SDMMC_GetCmdResp2(SDMMC_TypeDef *SDMMCx);
+uint32_t SDMMC_GetCmdResp3(SDMMC_TypeDef *SDMMCx);
+uint32_t SDMMC_GetCmdResp6(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint16_t *pRCA);
+uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx);
 /**
   * @}
   */
-
+  
 /**
   * @}
   */
+  
+/**
+  * @}
+  */ 
 
 /**
   * @}
@@ -1017,5 +1034,3 @@ uint32_t SDMMC_CmdSwitch(SDMMC_TypeDef *SDMMCx, uint32_t Argument);
 #endif
 
 #endif /* STM32F7xx_LL_SDMMC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + MMC card Control functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -195,7 +206,7 @@
     The compilation define USE_HAL_MMC_REGISTER_CALLBACKS when set to 1
     allows the user to configure dynamically the driver callbacks.
 
-    Use Functions @ref HAL_MMC_RegisterCallback() to register a user callback,
+    Use Functions HAL_MMC_RegisterCallback() to register a user callback,
     it allows to register following callbacks:
       (+) TxCpltCallback : callback when a transmission transfer is completed.
       (+) RxCpltCallback : callback when a reception transfer is completed.
@@ -206,7 +217,7 @@
     This function takes as parameters the HAL peripheral handle, the Callback ID
     and a pointer to the user callback function.
 
-    Use function @ref HAL_MMC_UnRegisterCallback() to reset a callback to the default
+    Use function HAL_MMC_UnRegisterCallback() to reset a callback to the default
     weak (surcharged) function. It allows to reset following callbacks:
       (+) TxCpltCallback : callback when a transmission transfer is completed.
       (+) RxCpltCallback : callback when a reception transfer is completed.
@@ -216,12 +227,12 @@
       (+) MspDeInitCallback  : MMC MspDeInit.
     This function) takes as parameters the HAL peripheral handle and the Callback ID.
 
-    By default, after the @ref HAL_MMC_Init and if the state is HAL_MMC_STATE_RESET
+    By default, after the HAL_MMC_Init and if the state is HAL_MMC_STATE_RESET
     all callbacks are reset to the corresponding legacy weak (surcharged) functions.
     Exception done for MspInit and MspDeInit callbacks that are respectively
-    reset to the legacy weak (surcharged) functions in the @ref HAL_MMC_Init
-    and @ref  HAL_MMC_DeInit only when these callbacks are null (not registered beforehand).
-    If not, MspInit or MspDeInit are not null, the @ref HAL_MMC_Init and @ref HAL_MMC_DeInit
+    reset to the legacy weak (surcharged) functions in the HAL_MMC_Init
+    and  HAL_MMC_DeInit only when these callbacks are null (not registered beforehand).
+    If not, MspInit or MspDeInit are not null, the HAL_MMC_Init and HAL_MMC_DeInit
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
 
     Callbacks can be registered/unregistered in READY state only.
@@ -229,25 +240,14 @@
     in READY or RESET state, thus registered (user) MspInit/DeInit callbacks can be used
     during the Init/DeInit.
     In that case first register the MspInit/MspDeInit user callbacks
-    using @ref HAL_MMC_RegisterCallback before calling @ref HAL_MMC_DeInit
-    or @ref HAL_MMC_Init function.
+    using HAL_MMC_RegisterCallback before calling HAL_MMC_DeInit
+    or HAL_MMC_Init function.
 
     When The compilation define USE_HAL_MMC_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registering feature is not available
     and weak (surcharged) callbacks are used.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -272,7 +272,30 @@
 /** @addtogroup MMC_Private_Defines
   * @{
   */
+#if defined (VDD_VALUE) && (VDD_VALUE <= 1950U)
+#define MMC_VOLTAGE_RANGE               EMMC_LOW_VOLTAGE_RANGE
 
+#define MMC_EXT_CSD_PWR_CL_26_INDEX     201
+#define MMC_EXT_CSD_PWR_CL_52_INDEX     200
+#define MMC_EXT_CSD_PWR_CL_DDR_52_INDEX 238
+
+#define MMC_EXT_CSD_PWR_CL_26_POS       8
+#define MMC_EXT_CSD_PWR_CL_52_POS       0
+#define MMC_EXT_CSD_PWR_CL_DDR_52_POS   16
+#else
+#define MMC_VOLTAGE_RANGE               EMMC_HIGH_VOLTAGE_RANGE
+
+#define MMC_EXT_CSD_PWR_CL_26_INDEX     203
+#define MMC_EXT_CSD_PWR_CL_52_INDEX     202
+#define MMC_EXT_CSD_PWR_CL_DDR_52_INDEX 239
+
+#define MMC_EXT_CSD_PWR_CL_26_POS       24
+#define MMC_EXT_CSD_PWR_CL_52_POS       16
+#define MMC_EXT_CSD_PWR_CL_DDR_52_POS   24
+#endif
+
+/* Frequencies used in the driver for clock divider calculation */
+#define MMC_INIT_FREQ                   400000U   /* Initalization phase : 400 kHz max */
 /**
   * @}
   */
@@ -296,6 +319,7 @@ static void     MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
 static void     MMC_DMAError(DMA_HandleTypeDef *hdma);
 static void     MMC_DMATxAbort(DMA_HandleTypeDef *hdma);
 static void     MMC_DMARxAbort(DMA_HandleTypeDef *hdma);
+static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide);
 /**
   * @}
   */
@@ -375,13 +399,22 @@ HAL_StatusTypeDef HAL_MMC_Init(MMC_HandleTypeDef *hmmc)
   }
 
   /* Initialize the error code */
-  hmmc->ErrorCode = HAL_DMA_ERROR_NONE;
+  hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
   /* Initialize the MMC operation */
   hmmc->Context = MMC_CONTEXT_NONE;
 
   /* Initialize the MMC state */
   hmmc->State = HAL_MMC_STATE_READY;
+
+  /* Configure bus width */
+  if (hmmc->Init.BusWide != SDMMC_BUS_WIDE_1B)
+  {
+    if (HAL_MMC_ConfigWideBusOperation(hmmc, hmmc->Init.BusWide) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+  }
 
   return HAL_OK;
 }
@@ -426,6 +459,9 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Enable MMC Clock */
   __HAL_MMC_ENABLE(hmmc);
+
+  /* Required power up waiting time before starting the MMC initialization  sequence */
+  HAL_Delay(2);
 
   /* Identify card operating voltage */
   errorstate = MMC_PowerON(hmmc);
@@ -1135,7 +1171,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
 
   if(hmmc->State == HAL_MMC_STATE_READY)
   {
-    hmmc->ErrorCode = HAL_DMA_ERROR_NONE;
+    hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
     if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
@@ -2081,6 +2117,148 @@ HAL_StatusTypeDef HAL_MMC_GetCardInfo(MMC_HandleTypeDef *hmmc, HAL_MMC_CardInfoT
 }
 
 /**
+  * @brief  Returns information the information of the card which are stored on
+  *         the Extended CSD register.
+  * @param  hmmc Pointer to MMC handle
+  * @param  pExtCSD Pointer to a memory area (512 bytes) that contains all
+  *         Extended CSD register parameters
+  * @param  Timeout Specify timeout value
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtCSD, uint32_t Timeout)
+{
+  SDMMC_DataInitTypeDef config;
+  uint32_t errorstate;
+  uint32_t tickstart = HAL_GetTick();
+  uint32_t count;
+  uint32_t *tmp_buf;
+
+  if(NULL == pExtCSD)
+  {
+    hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
+    return HAL_ERROR;
+  }
+
+  if(hmmc->State == HAL_MMC_STATE_READY)
+  {
+    hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
+
+    hmmc->State = HAL_MMC_STATE_BUSY;
+
+    /* Initialize data control register */
+    hmmc->Instance->DCTRL = 0;
+
+    /* Initiaize the destination pointer */
+    tmp_buf = pExtCSD;
+
+    /* Configure the MMC DPSM (Data Path State Machine) */
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = 512;
+    config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
+    (void)SDMMC_ConfigData(hmmc->Instance, &config);
+
+    /* Send ExtCSD Read command to Card */
+    errorstate = SDMMC_CmdSendEXTCSD(hmmc->Instance, 0);
+    if(errorstate != HAL_MMC_ERROR_NONE)
+    {
+      /* Clear all the static flags */
+      __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+      hmmc->ErrorCode |= errorstate;
+      hmmc->State = HAL_MMC_STATE_READY;
+      return HAL_ERROR;
+    }
+
+    /* Poll on SDMMC flags */
+    while(!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    {
+      if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF))
+      {
+        /* Read data from SDMMC Rx FIFO */
+        for(count = 0U; count < 8U; count++)
+        {
+          *tmp_buf = SDMMC_ReadFIFO(hmmc->Instance);
+          tmp_buf++;
+        }
+      }
+
+      if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
+      {
+        /* Clear all the static flags */
+        __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+        hmmc->ErrorCode |= HAL_MMC_ERROR_TIMEOUT;
+        hmmc->State= HAL_MMC_STATE_READY;
+        return HAL_TIMEOUT;
+      }
+    }
+
+    /* Get error state */
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
+    {
+      /* Clear all the static flags */
+      __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+      hmmc->ErrorCode |= HAL_MMC_ERROR_DATA_TIMEOUT;
+      hmmc->State = HAL_MMC_STATE_READY;
+      return HAL_ERROR;
+    }
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
+    {
+      /* Clear all the static flags */
+      __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+      hmmc->ErrorCode |= HAL_MMC_ERROR_DATA_CRC_FAIL;
+      hmmc->State = HAL_MMC_STATE_READY;
+      return HAL_ERROR;
+    }
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR))
+    {
+      /* Clear all the static flags */
+      __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+      hmmc->ErrorCode |= HAL_MMC_ERROR_RX_OVERRUN;
+      hmmc->State = HAL_MMC_STATE_READY;
+      return HAL_ERROR;
+    }
+    else
+    {
+      /* Nothing to do */
+    }
+
+    /* Clear all the static flags */
+    __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
+    hmmc->State = HAL_MMC_STATE_READY;
+  }
+
+  return HAL_OK;
+}
+
+/**
+ * @brief Enable / Disable the MMC cache
+ * @param  hmmc: Pointer to MMC handle
+ * @param enable enables the cache if true (non-zero), disable otherwise
+ * @retval HAL status
+ */
+HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable)
+{
+  uint32_t errorstate;
+
+  if (enable)
+  {
+    errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03210100U);
+  }
+  else
+  {
+    errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03210000U);
+  }
+  if (errorstate != HAL_MMC_ERROR_NONE)
+  {
+    hmmc->ErrorCode |= errorstate;
+    return HAL_ERROR;
+  }
+  return HAL_OK;
+}
+
+/**
   * @brief  Enables wide bus operation for the requested card if supported by
   *         card.
   * @param  hmmc: Pointer to MMC handle
@@ -2093,10 +2271,10 @@ HAL_StatusTypeDef HAL_MMC_GetCardInfo(MMC_HandleTypeDef *hmmc, HAL_MMC_CardInfoT
   */
 HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32_t WideMode)
 {
-  __IO uint32_t count = 0U;
+  uint32_t count;
   SDMMC_InitTypeDef Init;
   uint32_t errorstate;
-  uint32_t response = 0U, busy = 0U;
+  uint32_t response = 0U;
 
   /* Check the parameters */
   assert_param(IS_SDMMC_BUS_WIDE(WideMode));
@@ -2104,115 +2282,83 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
   /* Change State */
   hmmc->State = HAL_MMC_STATE_BUSY;
 
-  /* Update Clock for Bus mode update */
-  Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
-  Init.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
-  Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-  Init.BusWide             = WideMode;
-  Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
-  Init.ClockDiv            = SDMMC_INIT_CLK_DIV;
-  /* Initialize SDMMC*/
-  (void)SDMMC_Init(hmmc->Instance, Init);
+  errorstate = MMC_PwrClassUpdate(hmmc, WideMode);
 
-  if(WideMode == SDMMC_BUS_WIDE_8B)
+  if(errorstate == HAL_MMC_ERROR_NONE)
   {
-    errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70200U);
-    if(errorstate != HAL_MMC_ERROR_NONE)
+    if(WideMode == SDMMC_BUS_WIDE_8B)
     {
-      hmmc->ErrorCode |= errorstate;
+      errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70200U);
     }
-  }
-  else if(WideMode == SDMMC_BUS_WIDE_4B)
-  {
-    errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70100U);
-    if(errorstate != HAL_MMC_ERROR_NONE)
+    else if(WideMode == SDMMC_BUS_WIDE_4B)
     {
-      hmmc->ErrorCode |= errorstate;
+      errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70100U);
     }
-  }
-  else if(WideMode == SDMMC_BUS_WIDE_1B)
-  {
-    errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70000U);
-    if(errorstate != HAL_MMC_ERROR_NONE)
+    else if(WideMode == SDMMC_BUS_WIDE_1B)
     {
-      hmmc->ErrorCode |= errorstate;
+      errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70000U);
     }
-  }
-  else
-  {
-    /* WideMode is not a valid argument*/
-    hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
-  }
-
-  /* Check for switch error and violation of the trial number of sending CMD 13 */
-  while(busy == 0U)
-  {
-    if(count == SDMMC_MAX_TRIAL)
+    else
     {
-      hmmc->State = HAL_MMC_STATE_READY;
-      hmmc->ErrorCode |= HAL_MMC_ERROR_REQUEST_NOT_APPLICABLE;
-      return HAL_ERROR;
-    }
-    count++;
-
-    /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
-    errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-    if(errorstate != HAL_MMC_ERROR_NONE)
-    {
-      hmmc->ErrorCode |= errorstate;
+      /* WideMode is not a valid argument*/
+      errorstate = HAL_MMC_ERROR_PARAM;
     }
 
-    /* Get command response */
-    response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
-
-    /* Get operating voltage*/
-    busy = (((response >> 7U) == 1U) ? 0U : 1U);
-  }
-
-  /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
-  count = SDMMC_DATATIMEOUT;
-  while((response & 0x00000100U) == 0U)
-  {
-    if(count == 0U)
+    /* Check for switch error and violation of the trial number of sending CMD 13 */
+    if(errorstate == HAL_MMC_ERROR_NONE)
     {
-      hmmc->State = HAL_MMC_STATE_READY;
-      hmmc->ErrorCode |= HAL_MMC_ERROR_REQUEST_NOT_APPLICABLE;
-      return HAL_ERROR;
+      /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
+      count = SDMMC_MAX_TRIAL;
+      do
+      {
+        errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
+        if(errorstate != HAL_MMC_ERROR_NONE)
+        {
+          break;
+        }
+
+        /* Get command response */
+        response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
+        count--;
+      }while(((response & 0x100U) == 0U) && (count != 0U));
+
+      /* Check the status after the switch command execution */
+      if ((count != 0U) && (errorstate == HAL_MMC_ERROR_NONE))
+      {
+        /* Check the bit SWITCH_ERROR of the device status */
+        if ((response & 0x80U) != 0U)
+        {
+          errorstate = SDMMC_ERROR_GENERAL_UNKNOWN_ERR;
+        }
+        else
+        {
+          /* Configure the SDMMC peripheral */
+          Init = hmmc->Init;
+          Init.BusWide = WideMode;
+          (void)SDMMC_Init(hmmc->Instance, Init);
+        }
+      }
+      else if (count == 0U)
+      {
+        errorstate = SDMMC_ERROR_TIMEOUT;
+      }
+      else
+      {
+        /* Nothing to do */
+      }
     }
-    count--;
-
-    /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
-    errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-    if(errorstate != HAL_MMC_ERROR_NONE)
-    {
-      hmmc->ErrorCode |= errorstate;
-    }
-
-    /* Get command response */
-    response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
-  }
-
-  if(hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
-  {
-    /* Clear all the static flags */
-    __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
-    hmmc->State = HAL_MMC_STATE_READY;
-    return HAL_ERROR;
-  }
-  else
-  {
-    /* Configure the SDMMC peripheral */
-    Init.ClockEdge           = hmmc->Init.ClockEdge;
-    Init.ClockBypass         = hmmc->Init.ClockBypass;
-    Init.ClockPowerSave      = hmmc->Init.ClockPowerSave;
-    Init.BusWide             = WideMode;
-    Init.HardwareFlowControl = hmmc->Init.HardwareFlowControl;
-    Init.ClockDiv            = hmmc->Init.ClockDiv;
-    (void)SDMMC_Init(hmmc->Instance, Init);
   }
 
   /* Change State */
   hmmc->State = HAL_MMC_STATE_READY;
+
+  if(errorstate != HAL_MMC_ERROR_NONE)
+  {
+    /* Clear all the static flags */
+    __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
+    hmmc->ErrorCode |= errorstate;
+    return HAL_ERROR;
+  }
 
   return HAL_OK;
 }
@@ -2574,7 +2720,8 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 {
   HAL_MMC_CardCSDTypeDef CSD;
   uint32_t errorstate;
-  uint16_t mmc_rca = 1U;
+  uint16_t mmc_rca = 2U;
+  MMC_InitTypeDef Init;
 
   /* Check the power State */
   if(SDMMC_GetPowerState(hmmc->Instance) == 0U)
@@ -2598,9 +2745,9 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
     hmmc->CID[3U] = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP4);
   }
 
-  /* Send CMD3 SET_REL_ADDR with argument 0 */
+  /* Send CMD3 SET_REL_ADDR with RCA = 2 (should be greater than 1) */
   /* MMC Card publishes its RCA. */
-  errorstate = SDMMC_CmdSetRelAdd(hmmc->Instance, mmc_rca);
+  errorstate = SDMMC_CmdSetRelAddMmc(hmmc->Instance, mmc_rca);
   if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
@@ -2640,8 +2787,30 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
     return hmmc->ErrorCode;
   }
 
-  /* Configure SDMMC peripheral interface */
-  (void)SDMMC_Init(hmmc->Instance, hmmc->Init);
+  /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
+  errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
+  if(errorstate != HAL_MMC_ERROR_NONE)
+  {
+    hmmc->ErrorCode |= errorstate;
+  }
+
+  /* Get Extended CSD parameters */
+  if (HAL_MMC_GetCardExtCSD(hmmc, hmmc->Ext_CSD, SDMMC_DATATIMEOUT) != HAL_OK)
+  {
+    return hmmc->ErrorCode;
+  }
+
+  /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
+  errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
+  if(errorstate != HAL_MMC_ERROR_NONE)
+  {
+    hmmc->ErrorCode |= errorstate;
+  }
+
+  /* Configure the SDMMC peripheral */
+  Init = hmmc->Init;
+  Init.BusWide = SDMMC_BUS_WIDE_1B;
+  (void)SDMMC_Init(hmmc->Instance, Init);
 
   /* All cards are initialized */
   return HAL_MMC_ERROR_NONE;
@@ -2674,8 +2843,8 @@ static uint32_t MMC_PowerON(MMC_HandleTypeDef *hmmc)
       return HAL_MMC_ERROR_INVALID_VOLTRANGE;
     }
 
-    /* SEND CMD1 APP_CMD with MMC_HIGH_VOLTAGE_RANGE(0xC0FF8000) as argument */
-    errorstate = SDMMC_CmdOpCondition(hmmc->Instance, eMMC_HIGH_VOLTAGE_RANGE);
+    /* SEND CMD1 APP_CMD with voltage range as argument */
+    errorstate = SDMMC_CmdOpCondition(hmmc->Instance, MMC_VOLTAGE_RANGE);
     if(errorstate != HAL_MMC_ERROR_NONE)
     {
       return HAL_MMC_ERROR_UNSUPPORTED_FEATURE;
@@ -2907,6 +3076,93 @@ static void MMC_Write_IT(MMC_HandleTypeDef *hmmc)
 }
 
 /**
+  * @brief  Update the power class of the device.
+  * @param  hmmc MMC handle
+  * @param  Wide Wide of MMC bus
+  * @param  Speed Speed of the MMC bus
+  * @retval MMC Card error state
+  */
+static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
+{
+  uint32_t count;
+  uint32_t response = 0U;
+  uint32_t errorstate = HAL_MMC_ERROR_NONE;
+  uint32_t power_class, supported_pwr_class;
+
+  if((Wide == SDMMC_BUS_WIDE_8B) || (Wide == SDMMC_BUS_WIDE_4B))
+  {
+    power_class = 0U; /* Default value after power-on or software reset */
+
+    /* Read the PowerClass field of the Extended CSD register */
+    if(MMC_ReadExtCSD(hmmc, &power_class, 187, SDMMC_DATATIMEOUT) != HAL_OK) /* Field POWER_CLASS [187] */
+    {
+      errorstate = SDMMC_ERROR_GENERAL_UNKNOWN_ERR;
+    }
+    else
+    {
+      power_class = ((power_class >> 24U) & 0x000000FFU);
+    }
+
+    /* Get the supported PowerClass field of the Extended CSD register */
+    /* Field PWR_CL_26_xxx [201 or 203] */
+    supported_pwr_class = ((hmmc->Ext_CSD[(MMC_EXT_CSD_PWR_CL_26_INDEX/4)] >> MMC_EXT_CSD_PWR_CL_26_POS) & 0x000000FFU);
+
+    if(errorstate == HAL_MMC_ERROR_NONE)
+    {
+      if(Wide == SDMMC_BUS_WIDE_8B)
+      {
+        /* Bit [7:4] : power class for 8-bits bus configuration - Bit [3:0] : power class for 4-bits bus configuration */
+        supported_pwr_class = (supported_pwr_class >> 4U);
+      }
+
+      if ((power_class & 0x0FU) != (supported_pwr_class & 0x0FU))
+      {
+        /* Need to change current power class */
+        errorstate = SDMMC_CmdSwitch(hmmc->Instance, (0x03BB0000U | ((supported_pwr_class & 0x0FU) << 8U)));
+
+        if(errorstate == HAL_MMC_ERROR_NONE)
+        {
+          /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
+          count = SDMMC_MAX_TRIAL;
+          do
+          {
+            errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
+            if(errorstate != HAL_MMC_ERROR_NONE)
+            {
+              break;
+            }
+
+            /* Get command response */
+            response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
+            count--;
+          }while(((response & 0x100U) == 0U) && (count != 0U));
+
+          /* Check the status after the switch command execution */
+          if ((count != 0U) && (errorstate == HAL_MMC_ERROR_NONE))
+          {
+            /* Check the bit SWITCH_ERROR of the device status */
+            if ((response & 0x80U) != 0U)
+            {
+              errorstate = SDMMC_ERROR_UNSUPPORTED_FEATURE;
+            }
+          }
+          else if (count == 0U)
+          {
+            errorstate = SDMMC_ERROR_TIMEOUT;
+          }
+          else
+          {
+            /* Nothing to do */
+          }
+        }
+      }
+    }
+  }
+
+  return errorstate;
+}
+
+/**
   * @}
   */
 
@@ -2921,5 +3177,3 @@ static void MMC_Write_IT(MMC_HandleTypeDef *hmmc)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_sd.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_sd.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -199,7 +210,7 @@
     The compilation define USE_HAL_SD_REGISTER_CALLBACKS when set to 1
     allows the user to configure dynamically the driver callbacks.
 
-    Use Functions @ref HAL_SD_RegisterCallback() to register a user callback,
+    Use Functions HAL_SD_RegisterCallback() to register a user callback,
     it allows to register following callbacks:
       (+) TxCpltCallback : callback when a transmission transfer is completed.
       (+) RxCpltCallback : callback when a reception transfer is completed.
@@ -210,7 +221,7 @@
     This function takes as parameters the HAL peripheral handle, the Callback ID
     and a pointer to the user callback function.
 
-    Use function @ref HAL_SD_UnRegisterCallback() to reset a callback to the default
+    Use function HAL_SD_UnRegisterCallback() to reset a callback to the default
     weak (surcharged) function. It allows to reset following callbacks:
       (+) TxCpltCallback : callback when a transmission transfer is completed.
       (+) RxCpltCallback : callback when a reception transfer is completed.
@@ -220,12 +231,12 @@
       (+) MspDeInitCallback  : SD MspDeInit.
     This function) takes as parameters the HAL peripheral handle and the Callback ID.
 
-    By default, after the @ref HAL_SD_Init and if the state is HAL_SD_STATE_RESET
+    By default, after the HAL_SD_Init and if the state is HAL_SD_STATE_RESET
     all callbacks are reset to the corresponding legacy weak (surcharged) functions.
     Exception done for MspInit and MspDeInit callbacks that are respectively
-    reset to the legacy weak (surcharged) functions in the @ref HAL_SD_Init
-    and @ref  HAL_SD_DeInit only when these callbacks are null (not registered beforehand).
-    If not, MspInit or MspDeInit are not null, the @ref HAL_SD_Init and @ref HAL_SD_DeInit
+    reset to the legacy weak (surcharged) functions in the HAL_SD_Init
+    and  HAL_SD_DeInit only when these callbacks are null (not registered beforehand).
+    If not, MspInit or MspDeInit are not null, the HAL_SD_Init and HAL_SD_DeInit
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
 
     Callbacks can be registered/unregistered in READY state only.
@@ -233,25 +244,14 @@
     in READY or RESET state, thus registered (user) MspInit/DeInit callbacks can be used
     during the Init/DeInit.
     In that case first register the MspInit/MspDeInit user callbacks
-    using @ref HAL_SD_RegisterCallback before calling @ref HAL_SD_DeInit
-    or @ref HAL_SD_Init function.
+    using HAL_SD_RegisterCallback before calling HAL_SD_DeInit
+    or HAL_SD_Init function.
 
     When The compilation define USE_HAL_SD_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registering feature is not available
     and weak (surcharged) callbacks are used.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -429,6 +429,9 @@ HAL_StatusTypeDef HAL_SD_InitCard(SD_HandleTypeDef *hsd)
 
   /* Enable SDMMC Clock */
   __HAL_SD_ENABLE(hsd);
+
+  /* Required power up waiting time before starting the SD initialization  sequence */
+  HAL_Delay(2);
 
   /* Identify card operating voltage */
   errorstate = SD_PowerON(hsd);
@@ -2646,7 +2649,7 @@ static uint32_t SD_InitCard(SD_HandleTypeDef *hsd)
   {
     /* Send CMD3 SET_REL_ADDR with argument 0 */
     /* SD Card publishes its RCA. */
-    errorstate = SDMMC_CmdSendRelAdd(hsd->Instance, &sd_rca);
+    errorstate = SDMMC_CmdSetRelAdd(hsd->Instance, &sd_rca);
     if(errorstate != HAL_SD_ERROR_NONE)
     {
       return errorstate;
@@ -3219,5 +3222,3 @@ static void SD_Write_IT(SD_HandleTypeDef *hsd)
   */
 
 #endif /* SDMMC1 */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_sdmmc.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_sdmmc.c
@@ -11,6 +11,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                        ##### SDMMC peripheral features #####
@@ -142,17 +153,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -177,11 +177,6 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 static uint32_t SDMMC_GetCmdError(SDMMC_TypeDef *SDMMCx);
-static uint32_t SDMMC_GetCmdResp1(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint32_t Timeout);
-static uint32_t SDMMC_GetCmdResp2(SDMMC_TypeDef *SDMMCx);
-static uint32_t SDMMC_GetCmdResp3(SDMMC_TypeDef *SDMMCx);
-static uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx);
-static uint32_t SDMMC_GetCmdResp6(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint16_t *pRCA);
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -310,10 +305,6 @@ HAL_StatusTypeDef SDMMC_PowerState_ON(SDMMC_TypeDef *SDMMCx)
 {
   /* Set power state to ON */
   SDMMCx->POWER = SDMMC_POWER_PWRCTRL;
-
-  /* 1ms: required power up waiting time before starting the SD initialization
-  sequence */
-  HAL_Delay(2);
 
   return HAL_OK;
 }
@@ -1002,37 +993,12 @@ uint32_t SDMMC_CmdSendCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument)
 }
 
 /**
-  * @brief  Send the Set CSD command and check the response.
-  * @param  SDMMCx: Pointer to SDMMC register base
-  * @param  RCA: Card RCA
-  * @retval HAL status
-  */
-uint32_t SDMMC_CmdSetRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t RCA)
-{
-  SDMMC_CmdInitTypeDef  sdmmc_cmdinit;
-  uint32_t errorstate;
-
-  /* Send CMD3 SD_CMD_SET_REL_ADDR */
-  sdmmc_cmdinit.Argument         = RCA << 16;
-  sdmmc_cmdinit.CmdIndex         = SDMMC_CMD_SET_REL_ADDR;
-  sdmmc_cmdinit.Response         = SDMMC_RESPONSE_SHORT;
-  sdmmc_cmdinit.WaitForInterrupt = SDMMC_WAIT_NO;
-  sdmmc_cmdinit.CPSM             = SDMMC_CPSM_ENABLE;
-  (void)SDMMC_SendCommand(SDMMCx, &sdmmc_cmdinit);
-
-  /* Check for error conditions */
-  errorstate = SDMMC_GetCmdResp1(SDMMCx, SDMMC_CMD_SET_REL_ADDR, SDMMC_CMDTIMEOUT);
-
-  return errorstate;
-}
-
-/**
   * @brief  Send the Send CSD command and check the response.
   * @param  SDMMCx: Pointer to SDMMC register base
   * @param  pRCA: Card RCA
   * @retval HAL status
   */
-uint32_t SDMMC_CmdSendRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA)
+uint32_t SDMMC_CmdSetRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA)
 {
   SDMMC_CmdInitTypeDef  sdmmc_cmdinit;
   uint32_t errorstate;
@@ -1047,6 +1013,31 @@ uint32_t SDMMC_CmdSendRelAdd(SDMMC_TypeDef *SDMMCx, uint16_t *pRCA)
 
   /* Check for error conditions */
   errorstate = SDMMC_GetCmdResp6(SDMMCx, SDMMC_CMD_SET_REL_ADDR, pRCA);
+
+  return errorstate;
+}
+
+/**
+  * @brief  Send the Set Relative Address command to MMC card (not SD card).
+  * @param  SDMMCx Pointer to SDMMC register base
+  * @param  RCA Card RCA
+  * @retval HAL status
+  */
+uint32_t SDMMC_CmdSetRelAddMmc(SDMMC_TypeDef *SDMMCx, uint16_t RCA)
+{
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinit;
+  uint32_t errorstate;
+
+  /* Send CMD3 SD_CMD_SET_REL_ADDR */
+  sdmmc_cmdinit.Argument         = ((uint32_t)RCA << 16U);
+  sdmmc_cmdinit.CmdIndex         = SDMMC_CMD_SET_REL_ADDR;
+  sdmmc_cmdinit.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinit.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinit.CPSM             = SDMMC_CPSM_ENABLE;
+  (void)SDMMC_SendCommand(SDMMCx, &sdmmc_cmdinit);
+
+  /* Check for error conditions */
+  errorstate = SDMMC_GetCmdResp1(SDMMCx, SDMMC_CMD_SET_REL_ADDR, SDMMC_CMDTIMEOUT);
 
   return errorstate;
 }
@@ -1150,47 +1141,54 @@ uint32_t SDMMC_CmdSwitch(SDMMC_TypeDef *SDMMCx, uint32_t Argument)
 }
 
 /**
-  * @}
+  * @brief  Send the Send EXT_CSD command and check the response.
+  * @param  SDMMCx Pointer to SDMMC register base
+  * @param  Argument Command Argument
+  * @retval HAL status
   */
-
-/* Private function ----------------------------------------------------------*/
-/** @addtogroup SD_Private_Functions
-  * @{
-  */
-
-/**
-  * @brief  Checks for error conditions for CMD0.
-  * @param  hsd: SD handle
-  * @retval SD Card error state
-  */
-static uint32_t SDMMC_GetCmdError(SDMMC_TypeDef *SDMMCx)
+uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument)
 {
-  /* 8 is the number of required instructions cycles for the below loop statement.
-  The SDMMC_CMDTIMEOUT is expressed in ms */
-  uint32_t count = SDMMC_CMDTIMEOUT * (SystemCoreClock / 8U /1000U);
+  SDMMC_CmdInitTypeDef  sdmmc_cmdinit;
+  uint32_t errorstate;
 
-  do
-  {
-    if (count-- == 0U)
-    {
-      return SDMMC_ERROR_TIMEOUT;
-    }
+  /* Send CMD9 SEND_CSD */
+  sdmmc_cmdinit.Argument         = Argument;
+  sdmmc_cmdinit.CmdIndex         = SDMMC_CMD_HS_SEND_EXT_CSD;
+  sdmmc_cmdinit.Response         = SDMMC_RESPONSE_SHORT;
+  sdmmc_cmdinit.WaitForInterrupt = SDMMC_WAIT_NO;
+  sdmmc_cmdinit.CPSM             = SDMMC_CPSM_ENABLE;
+  (void)SDMMC_SendCommand(SDMMCx, &sdmmc_cmdinit);
 
-  }while(!__SDMMC_GET_FLAG(SDMMCx, SDMMC_FLAG_CMDSENT));
+  /* Check for error conditions */
+  errorstate = SDMMC_GetCmdResp1(SDMMCx, SDMMC_CMD_HS_SEND_EXT_CSD,SDMMC_CMDTIMEOUT);
 
-  /* Clear all the static flags */
-  __SDMMC_CLEAR_FLAG(SDMMCx, SDMMC_STATIC_CMD_FLAGS);
-
-  return SDMMC_ERROR_NONE;
+  return errorstate;
 }
 
 /**
+  * @}
+  */
+
+/** @defgroup HAL_SDMMC_LL_Group5 Responses management functions
+ *  @brief   Responses functions
+ *
+@verbatim
+ ===============================================================================
+                   ##### Responses management functions #####
+ ===============================================================================
+    [..]
+    This subsection provides a set of functions allowing to manage the needed responses.
+
+@endverbatim
+  * @{
+  */
+/**
   * @brief  Checks for error conditions for R1 response.
-  * @param  hsd: SD handle
+  * @param  SDMMCx Pointer to SDMMC register base
   * @param  SD_CMD: The sent command index
   * @retval SD Card error state
   */
-static uint32_t SDMMC_GetCmdResp1(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint32_t Timeout)
+uint32_t SDMMC_GetCmdResp1(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint32_t Timeout)
 {
   uint32_t response_r1;
   uint32_t sta_reg;
@@ -1322,10 +1320,10 @@ static uint32_t SDMMC_GetCmdResp1(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint32_
 
 /**
   * @brief  Checks for error conditions for R2 (CID or CSD) response.
-  * @param  hsd: SD handle
+  * @param  SDMMCx Pointer to SDMMC register base
   * @retval SD Card error state
   */
-static uint32_t SDMMC_GetCmdResp2(SDMMC_TypeDef *SDMMCx)
+uint32_t SDMMC_GetCmdResp2(SDMMC_TypeDef *SDMMCx)
 {
   uint32_t sta_reg;
   /* 8 is the number of required instructions cycles for the below loop statement.
@@ -1366,10 +1364,10 @@ static uint32_t SDMMC_GetCmdResp2(SDMMC_TypeDef *SDMMCx)
 
 /**
   * @brief  Checks for error conditions for R3 (OCR) response.
-  * @param  hsd: SD handle
+  * @param  SDMMCx Pointer to SDMMC register base
   * @retval SD Card error state
   */
-static uint32_t SDMMC_GetCmdResp3(SDMMC_TypeDef *SDMMCx)
+uint32_t SDMMC_GetCmdResp3(SDMMC_TypeDef *SDMMCx)
 {
   uint32_t sta_reg;
   /* 8 is the number of required instructions cycles for the below loop statement.
@@ -1403,13 +1401,13 @@ static uint32_t SDMMC_GetCmdResp3(SDMMC_TypeDef *SDMMCx)
 
 /**
   * @brief  Checks for error conditions for R6 (RCA) response.
-  * @param  hsd: SD handle
+  * @param  SDMMCx Pointer to SDMMC register base
   * @param  SD_CMD: The sent command index
   * @param  pRCA: Pointer to the variable that will contain the SD card relative
   *         address RCA
   * @retval SD Card error state
   */
-static uint32_t SDMMC_GetCmdResp6(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint16_t *pRCA)
+uint32_t SDMMC_GetCmdResp6(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint16_t *pRCA)
 {
   uint32_t response_r1;
   uint32_t sta_reg;
@@ -1479,10 +1477,10 @@ static uint32_t SDMMC_GetCmdResp6(SDMMC_TypeDef *SDMMCx, uint8_t SD_CMD, uint16_
 
 /**
   * @brief  Checks for error conditions for R7 response.
-  * @param  hsd: SD handle
+  * @param  SDMMCx Pointer to SDMMC register base
   * @retval SD Card error state
   */
-static uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx)
+uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx)
 {
   uint32_t sta_reg;
   /* 8 is the number of required instructions cycles for the below loop statement.
@@ -1529,28 +1527,38 @@ static uint32_t SDMMC_GetCmdResp7(SDMMC_TypeDef *SDMMCx)
 }
 
 /**
-  * @brief  Send the Send EXT_CSD command and check the response.
-  * @param  SDMMCx: Pointer to SDMMC register base
-  * @param  Argument: Command Argument
-  * @retval HAL status
+  * @}
   */
-uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument)
+
+/* Private function ----------------------------------------------------------*/
+/** @addtogroup SD_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Checks for error conditions for CMD0.
+  * @param  SDMMCx Pointer to SDMMC register base
+  * @retval SD Card error state
+  */
+static uint32_t SDMMC_GetCmdError(SDMMC_TypeDef *SDMMCx)
 {
-  SDMMC_CmdInitTypeDef  sdmmc_cmdinit;
-  uint32_t errorstate;
+  /* 8 is the number of required instructions cycles for the below loop statement.
+  The SDMMC_CMDTIMEOUT is expressed in ms */
+  uint32_t count = SDMMC_CMDTIMEOUT * (SystemCoreClock / 8U /1000U);
 
-  /* Send CMD9 SEND_CSD */
-  sdmmc_cmdinit.Argument         = Argument;
-  sdmmc_cmdinit.CmdIndex         = SDMMC_CMD_HS_SEND_EXT_CSD;
-  sdmmc_cmdinit.Response         = SDMMC_RESPONSE_SHORT;
-  sdmmc_cmdinit.WaitForInterrupt = SDMMC_WAIT_NO;
-  sdmmc_cmdinit.CPSM             = SDMMC_CPSM_ENABLE;
-  (void)SDMMC_SendCommand(SDMMCx, &sdmmc_cmdinit);
+  do
+  {
+    if (count-- == 0U)
+    {
+      return SDMMC_ERROR_TIMEOUT;
+    }
 
-  /* Check for error conditions */
-  errorstate = SDMMC_GetCmdResp1(SDMMCx, SDMMC_CMD_HS_SEND_EXT_CSD,SDMMC_CMDTIMEOUT);
+  }while(!__SDMMC_GET_FLAG(SDMMCx, SDMMC_FLAG_CMDSENT));
 
-  return errorstate;
+  /* Clear all the static flags */
+  __SDMMC_CLEAR_FLAG(SDMMCx, SDMMC_STATIC_CMD_FLAGS);
+
+  return SDMMC_ERROR_NONE;
 }
 
 
@@ -1568,5 +1576,3 @@ uint32_t SDMMC_CmdSendEXTCSD(SDMMC_TypeDef *SDMMCx, uint32_t Argument)
   */
 
 #endif /* SDMMC1 */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
This PR is a rebase of stradale-main onto the correct zephyr version for v3.0.0 (300109f80730cb2477bfcc706a6602b9870336b3)  and with updates for the SDIO and MMC drivers to use the latest STM upstream release. See e1a40d4d36a66c3a676687de231dea821700b4d7 for actual changes.

There is a separate PR to merge the rebase (see PR #4) which should reduce this to the actual changes. Please approve and merge that first!