### PR TITLE
SCF-885 SCF-859 hal_mmc: block interrupts while setting up DMA

### DIFF
--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
@@ -1177,11 +1177,13 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
 
   if (hmmc->State == HAL_MMC_STATE_READY)
   {
+    __disable_irq();
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
     if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
+      __enable_irq();
       return HAL_ERROR;
     }
 
@@ -1208,6 +1210,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
     hmmc->hdmarx->Init.Direction = DMA_PERIPH_TO_MEMORY;
     MODIFY_REG(hmmc->hdmarx->Instance->CR, DMA_SxCR_DIR, hmmc->hdmarx->Init.Direction);
 
+    __enable_irq();
     __HAL_MMC_ENABLE_IT(hmmc, (SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_RXOVERR | SDMMC_IT_DATAEND));
 
     /* Enable the DMA Channel */


### PR DESCRIPTION
While not immediately obvious why this is needed, when both the SAI and MMC drivers are being setup on DMA2 it is possible to corrupt the IP (intra-process) register and get a crash resulting. This crash _always_ occurs at the `MODIFY_REG` call for the stream control register, with an unaligned access violation. Block interrupts around this call as a stop gap fix.