### PR TITLE
SCF-885: copy upstream HAL DMA driver from STM

### DIFF
--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_dma.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_dma.c
@@ -84,13 +84,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2017 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file in
+  * the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -201,11 +200,12 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
     assert_param(IS_DMA_PERIPHERAL_BURST(hdma->Init.PeriphBurst));
   }
 
+  /* Change DMA peripheral state */
+  hdma->State = HAL_DMA_STATE_BUSY;
+
   /* Allocate lock resource */
   __HAL_UNLOCK(hdma);
 
-  /* Change DMA peripheral state */
-  hdma->State = HAL_DMA_STATE_BUSY;
 
   /* Disable the peripheral */
   __HAL_DMA_DISABLE(hdma);
@@ -552,11 +552,11 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
         /* Update error code */
         hdma->ErrorCode = HAL_DMA_ERROR_TIMEOUT;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hdma);
-
         /* Change the DMA state */
         hdma->State = HAL_DMA_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
 
         return HAL_TIMEOUT;
       }
@@ -565,11 +565,12 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
     /* Clear all interrupt flags at correct offset within the register */
     regs->IFCR = 0x3FU << hdma->StreamIndex;
 
+    /* Change the DMA state*/
+    hdma->State = HAL_DMA_STATE_READY;
+
     /* Process Unlocked */
     __HAL_UNLOCK(hdma);
 
-    /* Change the DMA state*/
-    hdma->State = HAL_DMA_STATE_READY;
   }
   return HAL_OK;
 }
@@ -660,11 +661,11 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
         /* Update error code */
         hdma->ErrorCode = HAL_DMA_ERROR_TIMEOUT;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hdma);
-
         /* Change the DMA state */
         hdma->State = HAL_DMA_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
 
         return HAL_TIMEOUT;
       }
@@ -710,11 +711,11 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
       /* Clear the half transfer and transfer complete flags */
       regs->IFCR = (DMA_FLAG_HTIF0_4 | DMA_FLAG_TCIF0_4) << hdma->StreamIndex;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hdma);
-
       /* Change the DMA state */
       hdma->State= HAL_DMA_STATE_READY;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hdma);
 
       return HAL_ERROR;
    }
@@ -726,10 +727,11 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
     /* Clear the half transfer and transfer complete flags */
     regs->IFCR = (DMA_FLAG_HTIF0_4 | DMA_FLAG_TCIF0_4) << hdma->StreamIndex;
 
+    hdma->State = HAL_DMA_STATE_READY;
+
     /* Process Unlocked */
     __HAL_UNLOCK(hdma);
 
-    hdma->State = HAL_DMA_STATE_READY;
   }
   else
   {
@@ -865,11 +867,11 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
         /* Clear all interrupt flags at correct offset within the register */
         regs->IFCR = 0x3FU << hdma->StreamIndex;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hdma);
-
         /* Change the DMA state */
         hdma->State = HAL_DMA_STATE_READY;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hdma);
 
         if(hdma->XferAbortCallback != NULL)
         {
@@ -907,11 +909,12 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
           /* Disable the transfer complete interrupt */
           hdma->Instance->CR  &= ~(DMA_IT_TC);
 
+          /* Change the DMA state */
+          hdma->State = HAL_DMA_STATE_READY;
+
           /* Process Unlocked */
           __HAL_UNLOCK(hdma);
 
-          /* Change the DMA state */
-          hdma->State = HAL_DMA_STATE_READY;
         }
 
         if(hdma->XferCpltCallback != NULL)
@@ -942,11 +945,12 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
       }
       while((hdma->Instance->CR & DMA_SxCR_EN) != RESET);
 
+      /* Change the DMA state */
+      hdma->State = HAL_DMA_STATE_READY;
+
       /* Process Unlocked */
       __HAL_UNLOCK(hdma);
 
-      /* Change the DMA state */
-      hdma->State = HAL_DMA_STATE_READY;
     }
 
     if(hdma->XferErrorCallback != NULL)
@@ -1004,6 +1008,8 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
       break;
 
     default:
+      /* Return error status */
+      status =  HAL_ERROR;
       break;
     }
   }
@@ -1304,4 +1310,3 @@ static HAL_StatusTypeDef DMA_CheckFifoParam(DMA_HandleTypeDef *hdma)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
From Release v1.16.2

From the release notes:
HAL DMA
Update HAL_DMA_IRQHandler() API to set the DMA state before unlocking access to the DMA handle.
Manage the case of an invalid value of CallbackID passed to the HAL_DMA_RegisterCallback() API.