### PR TITLE
SCF-1137 merge Logi update and latest STM HAL

### DIFF
--- a/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
+++ b/stm32cube/stm32f7xx/drivers/include/stm32f7xx_hal_mmc.h
@@ -627,6 +627,8 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
 /** @defgroup MMC_Exported_Functions_Group3 Peripheral Control functions
   * @{
   */
+HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable);
+HAL_StatusTypeDef HAL_MMC_FlushCache(MMC_HandleTypeDef *hmmc);
 HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32_t WideMode);
 /**
   * @}


### PR DESCRIPTION
This reworks an earlier commit that broke whitespace unnecessarily, and includes a minor improvement to the cache initialization to ensure that the cached extCSD is up to date. While this introduces no new functionality, it does mean that a log message during boot that was previously incorrect (claiming the cache was disabled) now prints the truth.