### PR TITLE
SCF-1137 merge Logi update and latest STM HAL

### DIFF
--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_hal_mmc.c
@@ -74,7 +74,7 @@
     SDMMC Peripheral (STM32 side) and the MMC Card, and put it into StandBy State (Ready for data transfer).
     This function provide the following operations:
 
-    (#) Initialize the SDMMC peripheral interface with defaullt configuration.
+    (#) Initialize the SDMMC peripheral interface with default configuration.
         The initialization process is done at 400KHz. You can change or adapt
         this frequency by adjusting the "ClockDiv" field.
         The MMC Card frequency (SDMMC_CK) is computed as follows:
@@ -255,13 +255,13 @@
 #include "stm32f7xx_hal.h"
 
 /** @addtogroup STM32F7xx_HAL_Driver
- * @{
- */
+  * @{
+  */
 
 /** @defgroup MMC MMC
- * @brief MMC HAL module driver
- * @{
- */
+  * @brief MMC HAL module driver
+  * @{
+  */
 
 #ifdef HAL_MMC_MODULE_ENABLED
 
@@ -270,63 +270,63 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /** @addtogroup MMC_Private_Defines
- * @{
- */
-#if defined(VDD_VALUE) && (VDD_VALUE <= 1950U)
-#define MMC_VOLTAGE_RANGE EMMC_LOW_VOLTAGE_RANGE
+  * @{
+  */
+#if defined (VDD_VALUE) && (VDD_VALUE <= 1950U)
+#define MMC_VOLTAGE_RANGE               EMMC_LOW_VOLTAGE_RANGE
 
-#define MMC_EXT_CSD_PWR_CL_26_INDEX 201
-#define MMC_EXT_CSD_PWR_CL_52_INDEX 200
+#define MMC_EXT_CSD_PWR_CL_26_INDEX     201
+#define MMC_EXT_CSD_PWR_CL_52_INDEX     200
 #define MMC_EXT_CSD_PWR_CL_DDR_52_INDEX 238
 
-#define MMC_EXT_CSD_PWR_CL_26_POS 8
-#define MMC_EXT_CSD_PWR_CL_52_POS 0
-#define MMC_EXT_CSD_PWR_CL_DDR_52_POS 16
+#define MMC_EXT_CSD_PWR_CL_26_POS       8
+#define MMC_EXT_CSD_PWR_CL_52_POS       0
+#define MMC_EXT_CSD_PWR_CL_DDR_52_POS   16
 #else
-#define MMC_VOLTAGE_RANGE EMMC_HIGH_VOLTAGE_RANGE
+#define MMC_VOLTAGE_RANGE               EMMC_HIGH_VOLTAGE_RANGE
 
-#define MMC_EXT_CSD_PWR_CL_26_INDEX 203
-#define MMC_EXT_CSD_PWR_CL_52_INDEX 202
+#define MMC_EXT_CSD_PWR_CL_26_INDEX     203
+#define MMC_EXT_CSD_PWR_CL_52_INDEX     202
 #define MMC_EXT_CSD_PWR_CL_DDR_52_INDEX 239
 
-#define MMC_EXT_CSD_PWR_CL_26_POS 24
-#define MMC_EXT_CSD_PWR_CL_52_POS 16
-#define MMC_EXT_CSD_PWR_CL_DDR_52_POS 24
+#define MMC_EXT_CSD_PWR_CL_26_POS       24
+#define MMC_EXT_CSD_PWR_CL_52_POS       16
+#define MMC_EXT_CSD_PWR_CL_DDR_52_POS   24
 #endif
 
 /* Frequencies used in the driver for clock divider calculation */
-#define MMC_INIT_FREQ 400000U /* Initalization phase : 400 kHz max */
+#define MMC_INIT_FREQ                   400000U   /* Initialization phase : 400 kHz max */
 /**
- * @}
- */
+  * @}
+  */
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 /** @defgroup MMC_Private_Functions MMC Private Functions
- * @{
- */
+  * @{
+  */
 static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc);
 static uint32_t MMC_PowerON(MMC_HandleTypeDef *hmmc);
 static uint32_t MMC_SendStatus(MMC_HandleTypeDef *hmmc, uint32_t *pCardStatus);
 static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, uint16_t FieldIndex, uint32_t Timeout);
-static void MMC_PowerOFF(MMC_HandleTypeDef *hmmc);
-static void MMC_Write_IT(MMC_HandleTypeDef *hmmc);
-static void MMC_Read_IT(MMC_HandleTypeDef *hmmc);
-static void MMC_DMATransmitCplt(DMA_HandleTypeDef *hdma);
-static void MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
-static void MMC_DMAError(DMA_HandleTypeDef *hdma);
-static void MMC_DMATxAbort(DMA_HandleTypeDef *hdma);
-static void MMC_DMARxAbort(DMA_HandleTypeDef *hdma);
+static void     MMC_PowerOFF(MMC_HandleTypeDef *hmmc);
+static void     MMC_Write_IT(MMC_HandleTypeDef *hmmc);
+static void     MMC_Read_IT(MMC_HandleTypeDef *hmmc);
+static void     MMC_DMATransmitCplt(DMA_HandleTypeDef *hdma);
+static void     MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
+static void     MMC_DMAError(DMA_HandleTypeDef *hdma);
+static void     MMC_DMATxAbort(DMA_HandleTypeDef *hdma);
+static void     MMC_DMARxAbort(DMA_HandleTypeDef *hdma);
 static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide);
 /**
- * @}
- */
+  * @}
+  */
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup MMC_Exported_Functions
- * @{
- */
+  * @{
+  */
 
 /** @addtogroup MMC_Exported_Functions_Group1
  *  @brief   Initialization and de-initialization functions
@@ -352,7 +352,7 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide);
 HAL_StatusTypeDef HAL_MMC_Init(MMC_HandleTypeDef *hmmc)
 {
   /* Check the MMC handle allocation */
-  if (hmmc == NULL)
+  if(hmmc == NULL)
   {
     return HAL_ERROR;
   }
@@ -366,18 +366,18 @@ HAL_StatusTypeDef HAL_MMC_Init(MMC_HandleTypeDef *hmmc)
   assert_param(IS_SDMMC_HARDWARE_FLOW_CONTROL(hmmc->Init.HardwareFlowControl));
   assert_param(IS_SDMMC_CLKDIV(hmmc->Init.ClockDiv));
 
-  if (hmmc->State == HAL_MMC_STATE_RESET)
+  if(hmmc->State == HAL_MMC_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
     hmmc->Lock = HAL_UNLOCKED;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
     /* Reset Callback pointers in HAL_MMC_STATE_RESET only */
-    hmmc->TxCpltCallback = HAL_MMC_TxCpltCallback;
-    hmmc->RxCpltCallback = HAL_MMC_RxCpltCallback;
-    hmmc->ErrorCallback = HAL_MMC_ErrorCallback;
+    hmmc->TxCpltCallback    = HAL_MMC_TxCpltCallback;
+    hmmc->RxCpltCallback    = HAL_MMC_RxCpltCallback;
+    hmmc->ErrorCallback     = HAL_MMC_ErrorCallback;
     hmmc->AbortCpltCallback = HAL_MMC_AbortCallback;
 
-    if (hmmc->MspInitCallback == NULL)
+    if(hmmc->MspInitCallback == NULL)
     {
       hmmc->MspInitCallback = HAL_MMC_MspInit;
     }
@@ -393,7 +393,7 @@ HAL_StatusTypeDef HAL_MMC_Init(MMC_HandleTypeDef *hmmc)
   hmmc->State = HAL_MMC_STATE_BUSY;
 
   /* Initialize the Card parameters */
-  if (HAL_MMC_InitCard(hmmc) == HAL_ERROR)
+  if(HAL_MMC_InitCard(hmmc) == HAL_ERROR)
   {
     return HAL_ERROR;
   }
@@ -433,16 +433,16 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
   HAL_StatusTypeDef status;
 
   /* Default SDMMC peripheral configuration for MMC card initialization */
-  Init.ClockEdge = SDMMC_CLOCK_EDGE_RISING;
-  Init.ClockBypass = SDMMC_CLOCK_BYPASS_DISABLE;
-  Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_DISABLE;
-  Init.BusWide = SDMMC_BUS_WIDE_1B;
+  Init.ClockEdge           = SDMMC_CLOCK_EDGE_RISING;
+  Init.ClockBypass         = SDMMC_CLOCK_BYPASS_DISABLE;
+  Init.ClockPowerSave      = SDMMC_CLOCK_POWER_SAVE_DISABLE;
+  Init.BusWide             = SDMMC_BUS_WIDE_1B;
   Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
-  Init.ClockDiv = SDMMC_INIT_CLK_DIV;
+  Init.ClockDiv            = SDMMC_INIT_CLK_DIV;
 
   /* Initialize SDMMC peripheral interface with default configuration */
   status = SDMMC_Init(hmmc->Instance, Init);
-  if (status == HAL_ERROR)
+  if(status == HAL_ERROR)
   {
     return HAL_ERROR;
   }
@@ -452,7 +452,7 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Set Power State to ON */
   status = SDMMC_PowerState_ON(hmmc->Instance);
-  if (status == HAL_ERROR)
+  if(status == HAL_ERROR)
   {
     return HAL_ERROR;
   }
@@ -465,7 +465,7 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Identify card operating voltage */
   errorstate = MMC_PowerON(hmmc);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->State = HAL_MMC_STATE_READY;
     hmmc->ErrorCode |= errorstate;
@@ -474,7 +474,7 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Card initialization */
   errorstate = MMC_InitCard(hmmc);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->State = HAL_MMC_STATE_READY;
     hmmc->ErrorCode |= errorstate;
@@ -483,7 +483,7 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Set Block Size for Card */
   errorstate = SDMMC_CmdBlockLength(hmmc->Instance, MMC_BLOCKSIZE);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     /* Clear all the static flags */
     __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -496,14 +496,14 @@ HAL_StatusTypeDef HAL_MMC_InitCard(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  De-Initializes the MMC card.
- * @param  hmmc: Pointer to MMC handle
- * @retval HAL status
- */
+  * @brief  De-Initializes the MMC card.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_DeInit(MMC_HandleTypeDef *hmmc)
 {
   /* Check the MMC handle allocation */
-  if (hmmc == NULL)
+  if(hmmc == NULL)
   {
     return HAL_ERROR;
   }
@@ -516,8 +516,8 @@ HAL_StatusTypeDef HAL_MMC_DeInit(MMC_HandleTypeDef *hmmc)
   /* Set MMC power state to off */
   MMC_PowerOFF(hmmc);
 
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
-  if (hmmc->MspDeInitCallback == NULL)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+  if(hmmc->MspDeInitCallback == NULL)
   {
     hmmc->MspDeInitCallback = HAL_MMC_MspDeInit;
   }
@@ -535,11 +535,12 @@ HAL_StatusTypeDef HAL_MMC_DeInit(MMC_HandleTypeDef *hmmc)
   return HAL_OK;
 }
 
+
 /**
- * @brief  Initializes the MMC MSP.
- * @param  hmmc: Pointer to MMC handle
- * @retval None
- */
+  * @brief  Initializes the MMC MSP.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_MspInit(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -551,10 +552,10 @@ __weak void HAL_MMC_MspInit(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  De-Initialize MMC MSP.
- * @param  hmmc: Pointer to MMC handle
- * @retval None
- */
+  * @brief  De-Initialize MMC MSP.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_MspDeInit(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -566,8 +567,8 @@ __weak void HAL_MMC_MspDeInit(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @}
- */
+  * @}
+  */
 
 /** @addtogroup MMC_Exported_Functions_Group2
  *  @brief   Data transfer functions
@@ -585,17 +586,17 @@ __weak void HAL_MMC_MspDeInit(MMC_HandleTypeDef *hmmc)
   */
 
 /**
- * @brief  Reads block(s) from a specified address in a card. The Data transfer
- *         is managed by polling mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @param  hmmc: Pointer to MMC handle
- * @param  pData: pointer to the buffer that will contain the received data
- * @param  BlockAdd: Block Address from where data is to be read
- * @param  NumberOfBlocks: Number of MMC blocks to read
- * @param  Timeout: Specify timeout value
- * @retval HAL status
- */
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer
+  *         is managed by polling mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pData: pointer to the buffer that will contain the received data
+  * @param  BlockAdd: Block Address from where data is to be read
+  * @param  NumberOfBlocks: Number of MMC blocks to read
+  * @param  Timeout: Specify timeout value
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks, uint32_t Timeout)
 {
   SDMMC_DataInitTypeDef config;
@@ -605,17 +606,17 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
   uint32_t add = BlockAdd;
   uint8_t *tempbuff = pData;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -632,16 +633,16 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
     }
 
     /* Configure the MMC DPSM (Data Path State Machine) */
-    config.DataTimeOut = SDMMC_DATATIMEOUT;
-    config.DataLength = NumberOfBlocks * MMC_BLOCKSIZE;
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = NumberOfBlocks * MMC_BLOCKSIZE;
     config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-    config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
-    config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-    config.DPSM = SDMMC_DPSM_ENABLE;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
     (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
     /* Read block(s) in polling mode */
-    if (NumberOfBlocks > 1U)
+    if(NumberOfBlocks > 1U)
     {
       hmmc->Context = MMC_CONTEXT_READ_MULTIPLE_BLOCK;
 
@@ -655,7 +656,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
       /* Read Single Block command */
       errorstate = SDMMC_CmdReadSingleBlock(hmmc->Instance, add);
     }
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -666,12 +667,12 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
 
     /* Poll on SDMMC flags */
     dataremaining = config.DataLength;
-    while (!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    while(!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
     {
-      if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF) && (dataremaining > 0U))
+      if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF) && (dataremaining > 0U))
       {
         /* Read data from SDMMC Rx FIFO */
-        for (count = 0U; count < 8U; count++)
+        for(count = 0U; count < 8U; count++)
         {
           data = SDMMC_ReadFIFO(hmmc->Instance);
           *tempbuff = (uint8_t)(data & 0xFFU);
@@ -689,22 +690,22 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
         }
       }
 
-      if (((HAL_GetTick() - tickstart) >= Timeout) || (Timeout == 0U))
+      if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
         hmmc->ErrorCode |= HAL_MMC_ERROR_TIMEOUT;
-        hmmc->State = HAL_MMC_STATE_READY;
+        hmmc->State= HAL_MMC_STATE_READY;
         return HAL_TIMEOUT;
       }
     }
 
     /* Send stop transmission command in case of multiblock read */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1U))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1U))
     {
       /* Send stop transmission command */
       errorstate = SDMMC_CmdStopTransfer(hmmc->Instance);
-      if (errorstate != HAL_MMC_ERROR_NONE)
+      if(errorstate != HAL_MMC_ERROR_NONE)
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -715,7 +716,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
     }
 
     /* Get error state */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -723,7 +724,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -731,7 +732,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -761,12 +762,12 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
       tempbuff++;
       dataremaining--;
 
-      if (((HAL_GetTick() - tickstart) >= Timeout) || (Timeout == 0U))
+      if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
         hmmc->ErrorCode |= HAL_MMC_ERROR_TIMEOUT;
-        hmmc->State = HAL_MMC_STATE_READY;
+        hmmc->State= HAL_MMC_STATE_READY;
         return HAL_ERROR;
       }
     }
@@ -786,17 +787,17 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, ui
 }
 
 /**
- * @brief  Allows to write block(s) to a specified address in a card. The Data
- *         transfer is managed by polling mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @param  hmmc: Pointer to MMC handle
- * @param  pData: pointer to the buffer that will contain the data to transmit
- * @param  BlockAdd: Block Address where data will be written
- * @param  NumberOfBlocks: Number of MMC blocks to write
- * @param  Timeout: Specify timeout value
- * @retval HAL status
- */
+  * @brief  Allows to write block(s) to a specified address in a card. The Data
+  *         transfer is managed by polling mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pData: pointer to the buffer that will contain the data to transmit
+  * @param  BlockAdd: Block Address where data will be written
+  * @param  NumberOfBlocks: Number of MMC blocks to write
+  * @param  Timeout: Specify timeout value
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks, uint32_t Timeout)
 {
   SDMMC_DataInitTypeDef config;
@@ -806,17 +807,17 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
   uint32_t add = BlockAdd;
   uint8_t *tempbuff = pData;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -833,7 +834,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
     }
 
     /* Write Blocks in Polling mode */
-    if (NumberOfBlocks > 1U)
+    if(NumberOfBlocks > 1U)
     {
       hmmc->Context = MMC_CONTEXT_WRITE_MULTIPLE_BLOCK;
 
@@ -847,7 +848,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
       /* Write Single Block command */
       errorstate = SDMMC_CmdWriteSingleBlock(hmmc->Instance, add);
     }
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -857,22 +858,22 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
     }
 
     /* Configure the MMC DPSM (Data Path State Machine) */
-    config.DataTimeOut = SDMMC_DATATIMEOUT;
-    config.DataLength = NumberOfBlocks * MMC_BLOCKSIZE;
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = NumberOfBlocks * MMC_BLOCKSIZE;
     config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-    config.TransferDir = SDMMC_TRANSFER_DIR_TO_CARD;
-    config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-    config.DPSM = SDMMC_DPSM_ENABLE;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
     (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
     /* Write block(s) in polling mode */
     dataremaining = config.DataLength;
-    while (!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    while(!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
     {
-      if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXFIFOHE) && (dataremaining > 0U))
+      if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXFIFOHE) && (dataremaining > 0U))
       {
         /* Write data to SDMMC Tx FIFO */
-        for (count = 0U; count < 8U; count++)
+        for(count = 0U; count < 8U; count++)
         {
           data = (uint32_t)(*tempbuff);
           tempbuff++;
@@ -890,7 +891,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
         }
       }
 
-      if (((HAL_GetTick() - tickstart) >= Timeout) || (Timeout == 0U))
+      if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -901,11 +902,11 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
     }
 
     /* Send stop transmission command in case of multiblock write */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1U))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) && (NumberOfBlocks > 1U))
     {
       /* Send stop transmission command */
       errorstate = SDMMC_CmdStopTransfer(hmmc->Instance);
-      if (errorstate != HAL_MMC_ERROR_NONE)
+      if(errorstate != HAL_MMC_ERROR_NONE)
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -916,7 +917,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
     }
 
     /* Get error state */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -924,7 +925,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -932,7 +933,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -960,35 +961,35 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks(MMC_HandleTypeDef *hmmc, uint8_t *pData, u
 }
 
 /**
- * @brief  Reads block(s) from a specified address in a card. The Data transfer
- *         is managed in interrupt mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @note   You could also check the IT transfer process through the MMC Rx
- *         interrupt event.
- * @param  hmmc: Pointer to MMC handle
- * @param  pData: Pointer to the buffer that will contain the received data
- * @param  BlockAdd: Block Address from where data is to be read
- * @param  NumberOfBlocks: Number of blocks to read.
- * @retval HAL status
- */
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer
+  *         is managed in interrupt mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @note   You could also check the IT transfer process through the MMC Rx
+  *         interrupt event.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pData: Pointer to the buffer that will contain the received data
+  * @param  BlockAdd: Block Address from where data is to be read
+  * @param  NumberOfBlocks: Number of blocks to read.
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_ReadBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks)
 {
   SDMMC_DataInitTypeDef config;
   uint32_t errorstate;
   uint32_t add = BlockAdd;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -1010,16 +1011,16 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData,
     }
 
     /* Configure the MMC DPSM (Data Path State Machine) */
-    config.DataTimeOut = SDMMC_DATATIMEOUT;
-    config.DataLength = MMC_BLOCKSIZE * NumberOfBlocks;
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = MMC_BLOCKSIZE * NumberOfBlocks;
     config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-    config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
-    config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-    config.DPSM = SDMMC_DPSM_ENABLE;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
     (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
     /* Read Blocks in IT mode */
-    if (NumberOfBlocks > 1U)
+    if(NumberOfBlocks > 1U)
     {
       hmmc->Context = (MMC_CONTEXT_READ_MULTIPLE_BLOCK | MMC_CONTEXT_IT);
 
@@ -1034,7 +1035,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData,
       errorstate = SDMMC_CmdReadSingleBlock(hmmc->Instance, add);
     }
 
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1052,35 +1053,35 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData,
 }
 
 /**
- * @brief  Writes block(s) to a specified address in a card. The Data transfer
- *         is managed in interrupt mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @note   You could also check the IT transfer process through the MMC Tx
- *         interrupt event.
- * @param  hmmc: Pointer to MMC handle
- * @param  pData: Pointer to the buffer that will contain the data to transmit
- * @param  BlockAdd: Block Address where data will be written
- * @param  NumberOfBlocks: Number of blocks to write
- * @retval HAL status
- */
+  * @brief  Writes block(s) to a specified address in a card. The Data transfer
+  *         is managed in interrupt mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @note   You could also check the IT transfer process through the MMC Tx
+  *         interrupt event.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pData: Pointer to the buffer that will contain the data to transmit
+  * @param  BlockAdd: Block Address where data will be written
+  * @param  NumberOfBlocks: Number of blocks to write
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_WriteBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks)
 {
   SDMMC_DataInitTypeDef config;
   uint32_t errorstate;
   uint32_t add = BlockAdd;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -1103,9 +1104,9 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData
     }
 
     /* Write Blocks in Polling mode */
-    if (NumberOfBlocks > 1U)
+    if(NumberOfBlocks > 1U)
     {
-      hmmc->Context = (MMC_CONTEXT_WRITE_MULTIPLE_BLOCK | MMC_CONTEXT_IT);
+      hmmc->Context = (MMC_CONTEXT_WRITE_MULTIPLE_BLOCK| MMC_CONTEXT_IT);
 
       /* Write Multi Block command */
       errorstate = SDMMC_CmdWriteMultiBlock(hmmc->Instance, add);
@@ -1117,7 +1118,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData
       /* Write Single Block command */
       errorstate = SDMMC_CmdWriteSingleBlock(hmmc->Instance, add);
     }
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1127,12 +1128,12 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData
     }
 
     /* Configure the MMC DPSM (Data Path State Machine) */
-    config.DataTimeOut = SDMMC_DATATIMEOUT;
-    config.DataLength = MMC_BLOCKSIZE * NumberOfBlocks;
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = MMC_BLOCKSIZE * NumberOfBlocks;
     config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-    config.TransferDir = SDMMC_TRANSFER_DIR_TO_CARD;
-    config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-    config.DPSM = SDMMC_DPSM_ENABLE;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
     (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
     return HAL_OK;
@@ -1144,35 +1145,35 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_IT(MMC_HandleTypeDef *hmmc, uint8_t *pData
 }
 
 /**
- * @brief  Reads block(s) from a specified address in a card. The Data transfer
- *         is managed by DMA mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @note   You could also check the DMA transfer process through the MMC Rx
- *         interrupt event.
- * @param  hmmc: Pointer MMC handle
- * @param  pData: Pointer to the buffer that will contain the received data
- * @param  BlockAdd: Block Address from where data is to be read
- * @param  NumberOfBlocks: Number of blocks to read.
- * @retval HAL status
- */
+  * @brief  Reads block(s) from a specified address in a card. The Data transfer
+  *         is managed by DMA mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @note   You could also check the DMA transfer process through the MMC Rx
+  *         interrupt event.
+  * @param  hmmc: Pointer MMC handle
+  * @param  pData: Pointer to the buffer that will contain the received data
+  * @param  BlockAdd: Block Address from where data is to be read
+  * @param  NumberOfBlocks: Number of blocks to read.
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks)
 {
   SDMMC_DataInitTypeDef config;
   uint32_t errorstate;
   uint32_t add = BlockAdd;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -1204,7 +1205,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
     MODIFY_REG(hmmc->hdmarx->Instance->CR, DMA_SxCR_DIR, hmmc->hdmarx->Init.Direction);
 
     /* Enable the DMA Channel */
-    if (HAL_DMA_Start_IT(hmmc->hdmarx, (uint32_t)&hmmc->Instance->FIFO, (uint32_t)pData, (uint32_t)(MMC_BLOCKSIZE * NumberOfBlocks) / 4) != HAL_OK)
+    if(HAL_DMA_Start_IT(hmmc->hdmarx, (uint32_t)&hmmc->Instance->FIFO, (uint32_t)pData, (uint32_t)(MMC_BLOCKSIZE * NumberOfBlocks)/4) != HAL_OK)
     {
       __HAL_MMC_DISABLE_IT(hmmc, (SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_RXOVERR | SDMMC_IT_DATAEND));
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1218,16 +1219,16 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
       __HAL_MMC_DMA_ENABLE(hmmc);
 
       /* Configure the MMC DPSM (Data Path State Machine) */
-      config.DataTimeOut = SDMMC_DATATIMEOUT;
-      config.DataLength = MMC_BLOCKSIZE * NumberOfBlocks;
+      config.DataTimeOut   = SDMMC_DATATIMEOUT;
+      config.DataLength    = MMC_BLOCKSIZE * NumberOfBlocks;
       config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-      config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
-      config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-      config.DPSM = SDMMC_DPSM_ENABLE;
+      config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+      config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+      config.DPSM          = SDMMC_DPSM_ENABLE;
       (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
       /* Read Blocks in DMA mode */
-      if (NumberOfBlocks > 1U)
+      if(NumberOfBlocks > 1U)
       {
         hmmc->Context = (MMC_CONTEXT_READ_MULTIPLE_BLOCK | MMC_CONTEXT_DMA);
 
@@ -1241,7 +1242,7 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
         /* Read Single Block command */
         errorstate = SDMMC_CmdReadSingleBlock(hmmc->Instance, add);
       }
-      if (errorstate != HAL_MMC_ERROR_NONE)
+      if(errorstate != HAL_MMC_ERROR_NONE)
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1261,35 +1262,35 @@ HAL_StatusTypeDef HAL_MMC_ReadBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData
 }
 
 /**
- * @brief  Writes block(s) to a specified address in a card. The Data transfer
- *         is managed by DMA mode.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @note   You could also check the DMA transfer process through the MMC Tx
- *         interrupt event.
- * @param  hmmc: Pointer to MMC handle
- * @param  pData: Pointer to the buffer that will contain the data to transmit
- * @param  BlockAdd: Block Address where data will be written
- * @param  NumberOfBlocks: Number of blocks to write
- * @retval HAL status
- */
+  * @brief  Writes block(s) to a specified address in a card. The Data transfer
+  *         is managed by DMA mode.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @note   You could also check the DMA transfer process through the MMC Tx
+  *         interrupt event.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pData: Pointer to the buffer that will contain the data to transmit
+  * @param  BlockAdd: Block Address where data will be written
+  * @param  NumberOfBlocks: Number of blocks to write
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pData, uint32_t BlockAdd, uint32_t NumberOfBlocks)
 {
   SDMMC_DataInitTypeDef config;
   uint32_t errorstate;
   uint32_t add = BlockAdd;
 
-  if (NULL == pData)
+  if(NULL == pData)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if ((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
+    if((BlockAdd + NumberOfBlocks) > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -1318,7 +1319,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pDat
     }
 
     /* Write Blocks in Polling mode */
-    if (NumberOfBlocks > 1U)
+    if(NumberOfBlocks > 1U)
     {
       hmmc->Context = (MMC_CONTEXT_WRITE_MULTIPLE_BLOCK | MMC_CONTEXT_DMA);
 
@@ -1332,7 +1333,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pDat
       /* Write Single Block command */
       errorstate = SDMMC_CmdWriteSingleBlock(hmmc->Instance, add);
     }
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1350,7 +1351,7 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pDat
     MODIFY_REG(hmmc->hdmatx->Instance->CR, DMA_SxCR_DIR, hmmc->hdmatx->Init.Direction);
 
     /* Enable the DMA Channel */
-    if (HAL_DMA_Start_IT(hmmc->hdmatx, (uint32_t)pData, (uint32_t)&hmmc->Instance->FIFO, (uint32_t)(MMC_BLOCKSIZE * NumberOfBlocks) / 4) != HAL_OK)
+    if(HAL_DMA_Start_IT(hmmc->hdmatx, (uint32_t)pData, (uint32_t)&hmmc->Instance->FIFO, (uint32_t)(MMC_BLOCKSIZE * NumberOfBlocks)/4) != HAL_OK)
     {
       __HAL_MMC_DISABLE_IT(hmmc, (SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT | SDMMC_IT_TXUNDERR | SDMMC_IT_DATAEND));
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1361,12 +1362,12 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pDat
     else
     {
       /* Configure the MMC DPSM (Data Path State Machine) */
-      config.DataTimeOut = SDMMC_DATATIMEOUT;
-      config.DataLength = MMC_BLOCKSIZE * NumberOfBlocks;
+      config.DataTimeOut   = SDMMC_DATATIMEOUT;
+      config.DataLength    = MMC_BLOCKSIZE * NumberOfBlocks;
       config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-      config.TransferDir = SDMMC_TRANSFER_DIR_TO_CARD;
-      config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-      config.DPSM = SDMMC_DPSM_ENABLE;
+      config.TransferDir   = SDMMC_TRANSFER_DIR_TO_CARD;
+      config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+      config.DPSM          = SDMMC_DPSM_ENABLE;
       (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
       return HAL_OK;
@@ -1379,31 +1380,31 @@ HAL_StatusTypeDef HAL_MMC_WriteBlocks_DMA(MMC_HandleTypeDef *hmmc, uint8_t *pDat
 }
 
 /**
- * @brief  Erases the specified memory area of the given MMC card.
- * @note   This API should be followed by a check on the card state through
- *         HAL_MMC_GetCardState().
- * @param  hmmc: Pointer to MMC handle
- * @param  BlockStartAdd: Start Block address
- * @param  BlockEndAdd: End Block address
- * @retval HAL status
- */
+  * @brief  Erases the specified memory area of the given MMC card.
+  * @note   This API should be followed by a check on the card state through
+  *         HAL_MMC_GetCardState().
+  * @param  hmmc: Pointer to MMC handle
+  * @param  BlockStartAdd: Start Block address
+  * @param  BlockEndAdd: End Block address
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd, uint32_t BlockEndAdd)
 {
   uint32_t errorstate;
   uint32_t start_add = BlockStartAdd;
   uint32_t end_add = BlockEndAdd;
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
-    if (end_add < start_add)
+    if(end_add < start_add)
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
       return HAL_ERROR;
     }
 
-    if (end_add > (hmmc->MmcCard.LogBlockNbr))
+    if(end_add > (hmmc->MmcCard.LogBlockNbr))
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_ADDR_OUT_OF_RANGE;
       return HAL_ERROR;
@@ -1412,7 +1413,7 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
     hmmc->State = HAL_MMC_STATE_BUSY;
 
     /* Check if the card command class supports erase command */
-    if (((hmmc->MmcCard.Class) & SDMMC_CCCC_ERASE) == 0U)
+    if(((hmmc->MmcCard.Class) & SDMMC_CCCC_ERASE) == 0U)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1421,7 +1422,7 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
       return HAL_ERROR;
     }
 
-    if ((SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1) & SDMMC_CARD_LOCKED) == SDMMC_CARD_LOCKED)
+    if((SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1) & SDMMC_CARD_LOCKED) == SDMMC_CARD_LOCKED)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1433,12 +1434,12 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
     if ((hmmc->MmcCard.CardType) != MMC_HIGH_CAPACITY_CARD)
     {
       start_add *= 512U;
-      end_add *= 512U;
+      end_add   *= 512U;
     }
 
     /* Send CMD35 MMC_ERASE_GRP_START with argument as addr  */
     errorstate = SDMMC_CmdEraseStartAdd(hmmc->Instance, start_add);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1449,7 +1450,7 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
 
     /* Send CMD36 MMC_ERASE_GRP_END with argument as addr  */
     errorstate = SDMMC_CmdEraseEndAdd(hmmc->Instance, end_add);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1460,7 +1461,7 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
 
     /* Send CMD38 ERASE */
     errorstate = SDMMC_CmdErase(hmmc->Instance);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -1480,71 +1481,71 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
 }
 
 /**
- * @brief  This function handles MMC card interrupt request.
- * @param  hmmc: Pointer to MMC handle
- * @retval None
- */
+  * @brief  This function handles MMC card interrupt request.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval None
+  */
 void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
 {
   uint32_t errorstate;
   uint32_t context = hmmc->Context;
 
   /* Check for SDMMC interrupt flags */
-  if ((__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF) != RESET) && ((context & MMC_CONTEXT_IT) != 0U))
+  if((__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF) != RESET) && ((context & MMC_CONTEXT_IT) != 0U))
   {
     MMC_Read_IT(hmmc);
   }
 
-  else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) != RESET)
+  else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DATAEND) != RESET)
   {
     __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_FLAG_DATAEND);
 
-    __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |
-                                   SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR | SDMMC_IT_TXFIFOHE |
-                                   SDMMC_IT_RXFIFOHF);
+    __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND  | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |\
+                               SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR  | SDMMC_IT_TXFIFOHE |\
+                               SDMMC_IT_RXFIFOHF);
 
     hmmc->Instance->DCTRL &= ~(SDMMC_DCTRL_DTEN);
 
-    if ((context & MMC_CONTEXT_DMA) != 0U)
+    if((context & MMC_CONTEXT_DMA) != 0U)
     {
-      if ((context & MMC_CONTEXT_WRITE_MULTIPLE_BLOCK) != 0U)
+      if((context & MMC_CONTEXT_WRITE_MULTIPLE_BLOCK) != 0U)
       {
         errorstate = SDMMC_CmdStopTransfer(hmmc->Instance);
-        if (errorstate != HAL_MMC_ERROR_NONE)
+        if(errorstate != HAL_MMC_ERROR_NONE)
         {
           hmmc->ErrorCode |= errorstate;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
           hmmc->ErrorCallback(hmmc);
 #else
           HAL_MMC_ErrorCallback(hmmc);
 #endif
         }
       }
-      if (((context & MMC_CONTEXT_READ_SINGLE_BLOCK) == 0U) && ((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) == 0U))
+      if(((context & MMC_CONTEXT_READ_SINGLE_BLOCK) == 0U) && ((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) == 0U))
       {
         /* Disable the DMA transfer for transmit request by setting the DMAEN bit
         in the MMC DCTRL register */
-        hmmc->Instance->DCTRL &= (uint32_t) ~((uint32_t)SDMMC_DCTRL_DMAEN);
+        hmmc->Instance->DCTRL &= (uint32_t)~((uint32_t)SDMMC_DCTRL_DMAEN);
 
         hmmc->State = HAL_MMC_STATE_READY;
 
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->TxCpltCallback(hmmc);
 #else
         HAL_MMC_TxCpltCallback(hmmc);
 #endif
       }
     }
-    else if ((context & MMC_CONTEXT_IT) != 0U)
+    else if((context & MMC_CONTEXT_IT) != 0U)
     {
       /* Stop Transfer for Write Multi blocks or Read Multi blocks */
-      if (((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) != 0U) || ((context & MMC_CONTEXT_WRITE_MULTIPLE_BLOCK) != 0U))
+      if(((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) != 0U) || ((context & MMC_CONTEXT_WRITE_MULTIPLE_BLOCK) != 0U))
       {
         errorstate = SDMMC_CmdStopTransfer(hmmc->Instance);
-        if (errorstate != HAL_MMC_ERROR_NONE)
+        if(errorstate != HAL_MMC_ERROR_NONE)
         {
           hmmc->ErrorCode |= errorstate;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
           hmmc->ErrorCallback(hmmc);
 #else
           HAL_MMC_ErrorCallback(hmmc);
@@ -1556,9 +1557,9 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
 
       hmmc->State = HAL_MMC_STATE_READY;
-      if (((context & MMC_CONTEXT_READ_SINGLE_BLOCK) != 0U) || ((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) != 0U))
+      if(((context & MMC_CONTEXT_READ_SINGLE_BLOCK) != 0U) || ((context & MMC_CONTEXT_READ_MULTIPLE_BLOCK) != 0U))
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->RxCpltCallback(hmmc);
 #else
         HAL_MMC_RxCpltCallback(hmmc);
@@ -1566,7 +1567,7 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
       }
       else
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->TxCpltCallback(hmmc);
 #else
         HAL_MMC_TxCpltCallback(hmmc);
@@ -1579,27 +1580,27 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
     }
   }
 
-  else if ((__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXFIFOHE) != RESET) && ((context & MMC_CONTEXT_IT) != 0U))
+  else if((__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXFIFOHE) != RESET) && ((context & MMC_CONTEXT_IT) != 0U))
   {
     MMC_Write_IT(hmmc);
   }
 
-  else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_RXOVERR | SDMMC_FLAG_TXUNDERR) != RESET)
+  else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_RXOVERR | SDMMC_FLAG_TXUNDERR) != RESET)
   {
     /* Set Error code */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL) != RESET)
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL) != RESET)
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_DATA_CRC_FAIL;
     }
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT) != RESET)
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT) != RESET)
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_DATA_TIMEOUT;
     }
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR) != RESET)
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR) != RESET)
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_RX_OVERRUN;
     }
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR) != RESET)
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_TXUNDERR) != RESET)
     {
       hmmc->ErrorCode |= HAL_MMC_ERROR_TX_UNDERRUN;
     }
@@ -1608,40 +1609,40 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
     __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
 
     /* Disable all interrupts */
-    __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |
-                                   SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR);
+    __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT|\
+                             SDMMC_IT_TXUNDERR| SDMMC_IT_RXOVERR);
 
     hmmc->ErrorCode |= SDMMC_CmdStopTransfer(hmmc->Instance);
 
-    if ((context & MMC_CONTEXT_IT) != 0U)
+    if((context & MMC_CONTEXT_IT) != 0U)
     {
       /* Set the MMC state to ready to be able to start again the process */
       hmmc->State = HAL_MMC_STATE_READY;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
       hmmc->ErrorCallback(hmmc);
 #else
       HAL_MMC_ErrorCallback(hmmc);
 #endif /* USE_HAL_MMC_REGISTER_CALLBACKS */
     }
-    else if ((context & MMC_CONTEXT_DMA) != 0U)
+    else if((context & MMC_CONTEXT_DMA) != 0U)
     {
       /* Abort the MMC DMA Streams */
-      if (hmmc->hdmatx != NULL)
+      if(hmmc->hdmatx != NULL)
       {
         /* Set the DMA Tx abort callback */
         hmmc->hdmatx->XferAbortCallback = MMC_DMATxAbort;
         /* Abort DMA in IT mode */
-        if (HAL_DMA_Abort_IT(hmmc->hdmatx) != HAL_OK)
+        if(HAL_DMA_Abort_IT(hmmc->hdmatx) != HAL_OK)
         {
           MMC_DMATxAbort(hmmc->hdmatx);
         }
       }
-      else if (hmmc->hdmarx != NULL)
+      else if(hmmc->hdmarx != NULL)
       {
         /* Set the DMA Rx abort callback */
         hmmc->hdmarx->XferAbortCallback = MMC_DMARxAbort;
         /* Abort DMA in IT mode */
-        if (HAL_DMA_Abort_IT(hmmc->hdmarx) != HAL_OK)
+        if(HAL_DMA_Abort_IT(hmmc->hdmarx) != HAL_OK)
         {
           MMC_DMARxAbort(hmmc->hdmarx);
         }
@@ -1650,7 +1651,7 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
       {
         hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
         hmmc->State = HAL_MMC_STATE_READY;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->AbortCpltCallback(hmmc);
 #else
         HAL_MMC_AbortCallback(hmmc);
@@ -1670,31 +1671,31 @@ void HAL_MMC_IRQHandler(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief return the MMC state
- * @param hmmc: Pointer to mmc handle
- * @retval HAL state
- */
+  * @brief return the MMC state
+  * @param hmmc: Pointer to mmc handle
+  * @retval HAL state
+  */
 HAL_MMC_StateTypeDef HAL_MMC_GetState(MMC_HandleTypeDef *hmmc)
 {
   return hmmc->State;
 }
 
 /**
- * @brief  Return the MMC error code
- * @param  hmmc : Pointer to a MMC_HandleTypeDef structure that contains
- *              the configuration information.
- * @retval MMC Error Code
- */
+* @brief  Return the MMC error code
+* @param  hmmc : Pointer to a MMC_HandleTypeDef structure that contains
+  *              the configuration information.
+* @retval MMC Error Code
+*/
 uint32_t HAL_MMC_GetError(MMC_HandleTypeDef *hmmc)
 {
   return hmmc->ErrorCode;
 }
 
 /**
- * @brief Tx Transfer completed callbacks
- * @param hmmc: Pointer to MMC handle
- * @retval None
- */
+  * @brief Tx Transfer completed callbacks
+  * @param hmmc: Pointer to MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_TxCpltCallback(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -1706,10 +1707,10 @@ __weak void HAL_MMC_TxCpltCallback(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief Rx Transfer completed callbacks
- * @param hmmc: Pointer MMC handle
- * @retval None
- */
+  * @brief Rx Transfer completed callbacks
+  * @param hmmc: Pointer MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_RxCpltCallback(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -1721,10 +1722,10 @@ __weak void HAL_MMC_RxCpltCallback(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief MMC error callbacks
- * @param hmmc: Pointer MMC handle
- * @retval None
- */
+  * @brief MMC error callbacks
+  * @param hmmc: Pointer MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_ErrorCallback(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -1736,10 +1737,10 @@ __weak void HAL_MMC_ErrorCallback(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief MMC Abort callbacks
- * @param hmmc: Pointer MMC handle
- * @retval None
- */
+  * @brief MMC Abort callbacks
+  * @param hmmc: Pointer MMC handle
+  * @retval None
+  */
 __weak void HAL_MMC_AbortCallback(MMC_HandleTypeDef *hmmc)
 {
   /* Prevent unused argument(s) compilation warning */
@@ -1750,27 +1751,27 @@ __weak void HAL_MMC_AbortCallback(MMC_HandleTypeDef *hmmc)
    */
 }
 
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
 /**
- * @brief  Register a User MMC Callback
- *         To be used instead of the weak (surcharged) predefined callback
- * @param hmmc : MMC handle
- * @param CallbackId : ID of the callback to be registered
- *        This parameter can be one of the following values:
- *          @arg @ref HAL_MMC_TX_CPLT_CB_ID    MMC Tx Complete Callback ID
- *          @arg @ref HAL_MMC_RX_CPLT_CB_ID    MMC Rx Complete Callback ID
- *          @arg @ref HAL_MMC_ERROR_CB_ID      MMC Error Callback ID
- *          @arg @ref HAL_MMC_ABORT_CB_ID      MMC Abort Callback ID
- *          @arg @ref HAL_MMC_MSP_INIT_CB_ID   MMC MspInit Callback ID
- *          @arg @ref HAL_MMC_MSP_DEINIT_CB_ID MMC MspDeInit Callback ID
- * @param pCallback : pointer to the Callback function
- * @retval status
- */
+  * @brief  Register a User MMC Callback
+  *         To be used instead of the weak (surcharged) predefined callback
+  * @param hmmc : MMC handle
+  * @param CallbackId : ID of the callback to be registered
+  *        This parameter can be one of the following values:
+  *          @arg @ref HAL_MMC_TX_CPLT_CB_ID    MMC Tx Complete Callback ID
+  *          @arg @ref HAL_MMC_RX_CPLT_CB_ID    MMC Rx Complete Callback ID
+  *          @arg @ref HAL_MMC_ERROR_CB_ID      MMC Error Callback ID
+  *          @arg @ref HAL_MMC_ABORT_CB_ID      MMC Abort Callback ID
+  *          @arg @ref HAL_MMC_MSP_INIT_CB_ID   MMC MspInit Callback ID
+  *          @arg @ref HAL_MMC_MSP_DEINIT_CB_ID MMC MspDeInit Callback ID
+  * @param pCallback : pointer to the Callback function
+  * @retval status
+  */
 HAL_StatusTypeDef HAL_MMC_RegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_CallbackIDTypeDef CallbackId, pMMC_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if (pCallback == NULL)
+  if(pCallback == NULL)
   {
     /* Update the error code */
     hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
@@ -1780,33 +1781,33 @@ HAL_StatusTypeDef HAL_MMC_RegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Call
   /* Process locked */
   __HAL_LOCK(hmmc);
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     switch (CallbackId)
     {
-    case HAL_MMC_TX_CPLT_CB_ID:
+    case HAL_MMC_TX_CPLT_CB_ID :
       hmmc->TxCpltCallback = pCallback;
       break;
-    case HAL_MMC_RX_CPLT_CB_ID:
+    case HAL_MMC_RX_CPLT_CB_ID :
       hmmc->RxCpltCallback = pCallback;
       break;
-    case HAL_MMC_ERROR_CB_ID:
+    case HAL_MMC_ERROR_CB_ID :
       hmmc->ErrorCallback = pCallback;
       break;
-    case HAL_MMC_ABORT_CB_ID:
+    case HAL_MMC_ABORT_CB_ID :
       hmmc->AbortCpltCallback = pCallback;
       break;
-    case HAL_MMC_MSP_INIT_CB_ID:
+    case HAL_MMC_MSP_INIT_CB_ID :
       hmmc->MspInitCallback = pCallback;
       break;
-    case HAL_MMC_MSP_DEINIT_CB_ID:
+    case HAL_MMC_MSP_DEINIT_CB_ID :
       hmmc->MspDeInitCallback = pCallback;
       break;
-    default:
+    default :
       /* Update the error code */
       hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
       /* update return status */
-      status = HAL_ERROR;
+      status =  HAL_ERROR;
       break;
     }
   }
@@ -1814,17 +1815,17 @@ HAL_StatusTypeDef HAL_MMC_RegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Call
   {
     switch (CallbackId)
     {
-    case HAL_MMC_MSP_INIT_CB_ID:
+    case HAL_MMC_MSP_INIT_CB_ID :
       hmmc->MspInitCallback = pCallback;
       break;
-    case HAL_MMC_MSP_DEINIT_CB_ID:
+    case HAL_MMC_MSP_DEINIT_CB_ID :
       hmmc->MspDeInitCallback = pCallback;
       break;
-    default:
+    default :
       /* Update the error code */
       hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
       /* update return status */
-      status = HAL_ERROR;
+      status =  HAL_ERROR;
       break;
     }
   }
@@ -1833,7 +1834,7 @@ HAL_StatusTypeDef HAL_MMC_RegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Call
     /* Update the error code */
     hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
     /* update return status */
-    status = HAL_ERROR;
+    status =  HAL_ERROR;
   }
 
   /* Release Lock */
@@ -1842,19 +1843,19 @@ HAL_StatusTypeDef HAL_MMC_RegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Call
 }
 
 /**
- * @brief  Unregister a User MMC Callback
- *         MMC Callback is redirected to the weak (surcharged) predefined callback
- * @param hmmc : MMC handle
- * @param CallbackId : ID of the callback to be unregistered
- *        This parameter can be one of the following values:
- *          @arg @ref HAL_MMC_TX_CPLT_CB_ID    MMC Tx Complete Callback ID
- *          @arg @ref HAL_MMC_RX_CPLT_CB_ID    MMC Rx Complete Callback ID
- *          @arg @ref HAL_MMC_ERROR_CB_ID      MMC Error Callback ID
- *          @arg @ref HAL_MMC_ABORT_CB_ID      MMC Abort Callback ID
- *          @arg @ref HAL_MMC_MSP_INIT_CB_ID   MMC MspInit Callback ID
- *          @arg @ref HAL_MMC_MSP_DEINIT_CB_ID MMC MspDeInit Callback ID
- * @retval status
- */
+  * @brief  Unregister a User MMC Callback
+  *         MMC Callback is redirected to the weak (surcharged) predefined callback
+  * @param hmmc : MMC handle
+  * @param CallbackId : ID of the callback to be unregistered
+  *        This parameter can be one of the following values:
+  *          @arg @ref HAL_MMC_TX_CPLT_CB_ID    MMC Tx Complete Callback ID
+  *          @arg @ref HAL_MMC_RX_CPLT_CB_ID    MMC Rx Complete Callback ID
+  *          @arg @ref HAL_MMC_ERROR_CB_ID      MMC Error Callback ID
+  *          @arg @ref HAL_MMC_ABORT_CB_ID      MMC Abort Callback ID
+  *          @arg @ref HAL_MMC_MSP_INIT_CB_ID   MMC MspInit Callback ID
+  *          @arg @ref HAL_MMC_MSP_DEINIT_CB_ID MMC MspDeInit Callback ID
+  * @retval status
+  */
 HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_CallbackIDTypeDef CallbackId)
 {
   HAL_StatusTypeDef status = HAL_OK;
@@ -1862,33 +1863,33 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
   /* Process locked */
   __HAL_LOCK(hmmc);
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     switch (CallbackId)
     {
-    case HAL_MMC_TX_CPLT_CB_ID:
+    case HAL_MMC_TX_CPLT_CB_ID :
       hmmc->TxCpltCallback = HAL_MMC_TxCpltCallback;
       break;
-    case HAL_MMC_RX_CPLT_CB_ID:
+    case HAL_MMC_RX_CPLT_CB_ID :
       hmmc->RxCpltCallback = HAL_MMC_RxCpltCallback;
       break;
-    case HAL_MMC_ERROR_CB_ID:
+    case HAL_MMC_ERROR_CB_ID :
       hmmc->ErrorCallback = HAL_MMC_ErrorCallback;
       break;
-    case HAL_MMC_ABORT_CB_ID:
+    case HAL_MMC_ABORT_CB_ID :
       hmmc->AbortCpltCallback = HAL_MMC_AbortCallback;
       break;
-    case HAL_MMC_MSP_INIT_CB_ID:
+    case HAL_MMC_MSP_INIT_CB_ID :
       hmmc->MspInitCallback = HAL_MMC_MspInit;
       break;
-    case HAL_MMC_MSP_DEINIT_CB_ID:
+    case HAL_MMC_MSP_DEINIT_CB_ID :
       hmmc->MspDeInitCallback = HAL_MMC_MspDeInit;
       break;
-    default:
+    default :
       /* Update the error code */
       hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
       /* update return status */
-      status = HAL_ERROR;
+      status =  HAL_ERROR;
       break;
     }
   }
@@ -1896,17 +1897,17 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
   {
     switch (CallbackId)
     {
-    case HAL_MMC_MSP_INIT_CB_ID:
+    case HAL_MMC_MSP_INIT_CB_ID :
       hmmc->MspInitCallback = HAL_MMC_MspInit;
       break;
-    case HAL_MMC_MSP_DEINIT_CB_ID:
+    case HAL_MMC_MSP_DEINIT_CB_ID :
       hmmc->MspDeInitCallback = HAL_MMC_MspDeInit;
       break;
-    default:
+    default :
       /* Update the error code */
       hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
       /* update return status */
-      status = HAL_ERROR;
+      status =  HAL_ERROR;
       break;
     }
   }
@@ -1915,7 +1916,7 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
     /* Update the error code */
     hmmc->ErrorCode |= HAL_MMC_ERROR_INVALID_CALLBACK;
     /* update return status */
-    status = HAL_ERROR;
+    status =  HAL_ERROR;
   }
 
   /* Release Lock */
@@ -1925,8 +1926,8 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
 #endif
 
 /**
- * @}
- */
+  * @}
+  */
 
 /** @addtogroup MMC_Exported_Functions_Group3
  *  @brief   management functions
@@ -1944,13 +1945,13 @@ HAL_StatusTypeDef HAL_MMC_UnRegisterCallback(MMC_HandleTypeDef *hmmc, HAL_MMC_Ca
   */
 
 /**
- * @brief  Returns information the information of the card which are stored on
- *         the CID register.
- * @param  hmmc: Pointer to MMC handle
- * @param  pCID: Pointer to a HAL_MMC_CIDTypedef structure that
- *         contains all CID register parameters
- * @retval HAL status
- */
+  * @brief  Returns information the information of the card which are stored on
+  *         the CID register.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pCID: Pointer to a HAL_MMC_CIDTypedef structure that
+  *         contains all CID register parameters
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_GetCardCID(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCIDTypeDef *pCID)
 {
   pCID->ManufacturerID = (uint8_t)((hmmc->CID[0] & 0xFF000000U) >> 24U);
@@ -1977,13 +1978,13 @@ HAL_StatusTypeDef HAL_MMC_GetCardCID(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCIDTyp
 }
 
 /**
- * @brief  Returns information the information of the card which are stored on
- *         the CSD register.
- * @param  hmmc: Pointer to MMC handle
- * @param  pCSD: Pointer to a HAL_MMC_CardCSDTypeDef structure that
- *         contains all CSD register parameters
- * @retval HAL status
- */
+  * @brief  Returns information the information of the card which are stored on
+  *         the CSD register.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pCSD: Pointer to a HAL_MMC_CardCSDTypeDef structure that
+  *         contains all CSD register parameters
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTypeDef *pCSD)
 {
   uint32_t block_nbr = 0;
@@ -2004,7 +2005,7 @@ HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTyp
 
   pCSD->RdBlockLen = (uint8_t)((hmmc->CSD[1] & 0x000F0000U) >> 16U);
 
-  pCSD->PartBlockRead = (uint8_t)((hmmc->CSD[1] & 0x00008000U) >> 15U);
+  pCSD->PartBlockRead   = (uint8_t)((hmmc->CSD[1] & 0x00008000U) >> 15U);
 
   pCSD->WrBlockMisalign = (uint8_t)((hmmc->CSD[1] & 0x00004000U) >> 14U);
 
@@ -2026,20 +2027,20 @@ HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTyp
 
   pCSD->DeviceSizeMul = (uint8_t)((hmmc->CSD[2] & 0x00038000U) >> 15U);
 
-  if (MMC_ReadExtCSD(hmmc, &block_nbr, 212, 0x0FFFFFFFU) != HAL_OK) /* Field SEC_COUNT [215:212] */
+  if(MMC_ReadExtCSD(hmmc, &block_nbr, 212, 0x0FFFFFFFU) != HAL_OK) /* Field SEC_COUNT [215:212] */
   {
     return HAL_ERROR;
   }
 
-  if (hmmc->MmcCard.CardType == MMC_LOW_CAPACITY_CARD)
+  if(hmmc->MmcCard.CardType == MMC_LOW_CAPACITY_CARD)
   {
-    hmmc->MmcCard.BlockNbr = (pCSD->DeviceSize + 1U);
+    hmmc->MmcCard.BlockNbr  = (pCSD->DeviceSize + 1U) ;
     hmmc->MmcCard.BlockNbr *= (1UL << ((pCSD->DeviceSizeMul & 0x07U) + 2U));
     hmmc->MmcCard.BlockSize = (1UL << (pCSD->RdBlockLen & 0x0FU));
-    hmmc->MmcCard.LogBlockNbr = (hmmc->MmcCard.BlockNbr) * ((hmmc->MmcCard.BlockSize) / 512U);
+    hmmc->MmcCard.LogBlockNbr =  (hmmc->MmcCard.BlockNbr) * ((hmmc->MmcCard.BlockSize) / 512U);
     hmmc->MmcCard.LogBlockSize = 512U;
   }
-  else if (hmmc->MmcCard.CardType == MMC_HIGH_CAPACITY_CARD)
+  else if(hmmc->MmcCard.CardType == MMC_HIGH_CAPACITY_CARD)
   {
     hmmc->MmcCard.BlockNbr = block_nbr;
     hmmc->MmcCard.LogBlockNbr = hmmc->MmcCard.BlockNbr;
@@ -2067,7 +2068,7 @@ HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTyp
 
   pCSD->WrSpeedFact = (uint8_t)((hmmc->CSD[3] & 0x1C000000U) >> 26U);
 
-  pCSD->MaxWrBlockLen = (uint8_t)((hmmc->CSD[3] & 0x03C00000U) >> 22U);
+  pCSD->MaxWrBlockLen= (uint8_t)((hmmc->CSD[3] & 0x03C00000U) >> 22U);
 
   pCSD->WriteBlockPaPartial = (uint8_t)((hmmc->CSD[3] & 0x00200000U) >> 21U);
 
@@ -2085,7 +2086,7 @@ HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTyp
 
   pCSD->FileFormat = (uint8_t)((hmmc->CSD[3] & 0x00000C00U) >> 10U);
 
-  pCSD->ECC = (uint8_t)((hmmc->CSD[3] & 0x00000300U) >> 8U);
+  pCSD->ECC= (uint8_t)((hmmc->CSD[3] & 0x00000300U) >> 8U);
 
   pCSD->CSD_CRC = (uint8_t)((hmmc->CSD[3] & 0x000000FEU) >> 1U);
 
@@ -2095,34 +2096,34 @@ HAL_StatusTypeDef HAL_MMC_GetCardCSD(MMC_HandleTypeDef *hmmc, HAL_MMC_CardCSDTyp
 }
 
 /**
- * @brief  Gets the MMC card info.
- * @param  hmmc: Pointer to MMC handle
- * @param  pCardInfo: Pointer to the HAL_MMC_CardInfoTypeDef structure that
- *         will contain the MMC card status information
- * @retval HAL status
- */
+  * @brief  Gets the MMC card info.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pCardInfo: Pointer to the HAL_MMC_CardInfoTypeDef structure that
+  *         will contain the MMC card status information
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_GetCardInfo(MMC_HandleTypeDef *hmmc, HAL_MMC_CardInfoTypeDef *pCardInfo)
 {
-  pCardInfo->CardType = (uint32_t)(hmmc->MmcCard.CardType);
-  pCardInfo->Class = (uint32_t)(hmmc->MmcCard.Class);
-  pCardInfo->RelCardAdd = (uint32_t)(hmmc->MmcCard.RelCardAdd);
-  pCardInfo->BlockNbr = (uint32_t)(hmmc->MmcCard.BlockNbr);
-  pCardInfo->BlockSize = (uint32_t)(hmmc->MmcCard.BlockSize);
-  pCardInfo->LogBlockNbr = (uint32_t)(hmmc->MmcCard.LogBlockNbr);
+  pCardInfo->CardType     = (uint32_t)(hmmc->MmcCard.CardType);
+  pCardInfo->Class        = (uint32_t)(hmmc->MmcCard.Class);
+  pCardInfo->RelCardAdd   = (uint32_t)(hmmc->MmcCard.RelCardAdd);
+  pCardInfo->BlockNbr     = (uint32_t)(hmmc->MmcCard.BlockNbr);
+  pCardInfo->BlockSize    = (uint32_t)(hmmc->MmcCard.BlockSize);
+  pCardInfo->LogBlockNbr  = (uint32_t)(hmmc->MmcCard.LogBlockNbr);
   pCardInfo->LogBlockSize = (uint32_t)(hmmc->MmcCard.LogBlockSize);
 
   return HAL_OK;
 }
 
 /**
- * @brief  Returns information the information of the card which are stored on
- *         the Extended CSD register.
- * @param  hmmc Pointer to MMC handle
- * @param  pExtCSD Pointer to a memory area (512 bytes) that contains all
- *         Extended CSD register parameters
- * @param  Timeout Specify timeout value
- * @retval HAL status
- */
+  * @brief  Returns information the information of the card which are stored on
+  *         the Extended CSD register.
+  * @param  hmmc Pointer to MMC handle
+  * @param  pExtCSD Pointer to a memory area (512 bytes) that contains all
+  *         Extended CSD register parameters
+  * @param  Timeout Specify timeout value
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtCSD, uint32_t Timeout)
 {
   SDMMC_DataInitTypeDef config;
@@ -2131,13 +2132,13 @@ HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtC
   uint32_t count;
   uint32_t *tmp_buf;
 
-  if (NULL == pExtCSD)
+  if(NULL == pExtCSD)
   {
     hmmc->ErrorCode |= HAL_MMC_ERROR_PARAM;
     return HAL_ERROR;
   }
 
-  if (hmmc->State == HAL_MMC_STATE_READY)
+  if(hmmc->State == HAL_MMC_STATE_READY)
   {
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
 
@@ -2150,17 +2151,17 @@ HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtC
     tmp_buf = pExtCSD;
 
     /* Configure the MMC DPSM (Data Path State Machine) */
-    config.DataTimeOut = SDMMC_DATATIMEOUT;
-    config.DataLength = 512;
+    config.DataTimeOut   = SDMMC_DATATIMEOUT;
+    config.DataLength    = 512;
     config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-    config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
-    config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-    config.DPSM = SDMMC_DPSM_ENABLE;
+    config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+    config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+    config.DPSM          = SDMMC_DPSM_ENABLE;
     (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
     /* Send ExtCSD Read command to Card */
     errorstate = SDMMC_CmdSendEXTCSD(hmmc->Instance, 0);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -2170,30 +2171,30 @@ HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtC
     }
 
     /* Poll on SDMMC flags */
-    while (!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+    while(!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
     {
-      if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF))
+      if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF))
       {
         /* Read data from SDMMC Rx FIFO */
-        for (count = 0U; count < 8U; count++)
+        for(count = 0U; count < 8U; count++)
         {
           *tmp_buf = SDMMC_ReadFIFO(hmmc->Instance);
           tmp_buf++;
         }
       }
 
-      if (((HAL_GetTick() - tickstart) >= Timeout) || (Timeout == 0U))
+      if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
       {
         /* Clear all the static flags */
         __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
         hmmc->ErrorCode |= HAL_MMC_ERROR_TIMEOUT;
-        hmmc->State = HAL_MMC_STATE_READY;
+        hmmc->State= HAL_MMC_STATE_READY;
         return HAL_TIMEOUT;
       }
     }
 
     /* Get error state */
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DTIMEOUT))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -2201,7 +2202,7 @@ HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtC
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_DCRCFAIL))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -2209,7 +2210,7 @@ HAL_StatusTypeDef HAL_MMC_GetCardExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pExtC
       hmmc->State = HAL_MMC_STATE_READY;
       return HAL_ERROR;
     }
-    else if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR))
+    else if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -2251,6 +2252,13 @@ HAL_StatusTypeDef HAL_MMC_Cache(MMC_HandleTypeDef *hmmc, uint32_t enable)
   if (errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->ErrorCode |= errorstate;
+    return HAL_ERROR;
+  }
+  /*
+   * re-read the extCSD since things have now changed
+   */
+  if (HAL_MMC_GetCardExtCSD(hmmc, hmmc->Ext_CSD, SDMMC_DATATIMEOUT) != HAL_OK)
+  {
     return HAL_ERROR;
   }
   return HAL_OK;
@@ -2311,16 +2319,16 @@ HAL_StatusTypeDef HAL_MMC_FlushCache(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Enables wide bus operation for the requested card if supported by
- *         card.
- * @param  hmmc: Pointer to MMC handle
- * @param  WideMode: Specifies the MMC card wide bus mode
- *          This parameter can be one of the following values:
- *            @arg SDMMC_BUS_WIDE_8B: 8-bit data transfer
- *            @arg SDMMC_BUS_WIDE_4B: 4-bit data transfer
- *            @arg SDMMC_BUS_WIDE_1B: 1-bit data transfer
- * @retval HAL status
- */
+  * @brief  Enables wide bus operation for the requested card if supported by
+  *         card.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  WideMode: Specifies the MMC card wide bus mode
+  *          This parameter can be one of the following values:
+  *            @arg SDMMC_BUS_WIDE_8B: 8-bit data transfer
+  *            @arg SDMMC_BUS_WIDE_4B: 4-bit data transfer
+  *            @arg SDMMC_BUS_WIDE_1B: 1-bit data transfer
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32_t WideMode)
 {
   uint32_t count;
@@ -2336,17 +2344,17 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
 
   errorstate = MMC_PwrClassUpdate(hmmc, WideMode);
 
-  if (errorstate == HAL_MMC_ERROR_NONE)
+  if(errorstate == HAL_MMC_ERROR_NONE)
   {
-    if (WideMode == SDMMC_BUS_WIDE_8B)
+    if(WideMode == SDMMC_BUS_WIDE_8B)
     {
       errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70200U);
     }
-    else if (WideMode == SDMMC_BUS_WIDE_4B)
+    else if(WideMode == SDMMC_BUS_WIDE_4B)
     {
       errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70100U);
     }
-    else if (WideMode == SDMMC_BUS_WIDE_1B)
+    else if(WideMode == SDMMC_BUS_WIDE_1B)
     {
       errorstate = SDMMC_CmdSwitch(hmmc->Instance, 0x03B70000U);
     }
@@ -2357,14 +2365,14 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
     }
 
     /* Check for switch error and violation of the trial number of sending CMD 13 */
-    if (errorstate == HAL_MMC_ERROR_NONE)
+    if(errorstate == HAL_MMC_ERROR_NONE)
     {
       /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
       count = SDMMC_MAX_TRIAL;
       do
       {
         errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-        if (errorstate != HAL_MMC_ERROR_NONE)
+        if(errorstate != HAL_MMC_ERROR_NONE)
         {
           break;
         }
@@ -2372,7 +2380,7 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
         /* Get command response */
         response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
         count--;
-      } while (((response & 0x100U) == 0U) && (count != 0U));
+      }while(((response & 0x100U) == 0U) && (count != 0U));
 
       /* Check the status after the switch command execution */
       if ((count != 0U) && (errorstate == HAL_MMC_ERROR_NONE))
@@ -2404,7 +2412,7 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
   /* Change State */
   hmmc->State = HAL_MMC_STATE_READY;
 
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     /* Clear all the static flags */
     __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -2416,10 +2424,10 @@ HAL_StatusTypeDef HAL_MMC_ConfigWideBusOperation(MMC_HandleTypeDef *hmmc, uint32
 }
 
 /**
- * @brief  Gets the current mmc card data state.
- * @param  hmmc: pointer to MMC handle
- * @retval Card state
- */
+  * @brief  Gets the current mmc card data state.
+  * @param  hmmc: pointer to MMC handle
+  * @retval Card state
+  */
 HAL_MMC_CardStateTypeDef HAL_MMC_GetCardState(MMC_HandleTypeDef *hmmc)
 {
   uint32_t cardstate;
@@ -2427,7 +2435,7 @@ HAL_MMC_CardStateTypeDef HAL_MMC_GetCardState(MMC_HandleTypeDef *hmmc)
   uint32_t resp1 = 0U;
 
   errorstate = MMC_SendStatus(hmmc, &resp1);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->ErrorCode |= errorstate;
   }
@@ -2438,39 +2446,39 @@ HAL_MMC_CardStateTypeDef HAL_MMC_GetCardState(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Abort the current transfer and disable the MMC.
- * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
- *                the configuration information for MMC module.
- * @retval HAL status
- */
+  * @brief  Abort the current transfer and disable the MMC.
+  * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
+  *                the configuration information for MMC module.
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_Abort(MMC_HandleTypeDef *hmmc)
 {
   HAL_MMC_CardStateTypeDef CardState;
 
   /* DIsable All interrupts */
-  __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |
-                                 SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR);
+  __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT|\
+                             SDMMC_IT_TXUNDERR| SDMMC_IT_RXOVERR);
 
   /* Clear All flags */
   __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
 
-  if ((hmmc->hdmatx != NULL) || (hmmc->hdmarx != NULL))
+  if((hmmc->hdmatx != NULL) || (hmmc->hdmarx != NULL))
   {
     /* Disable the MMC DMA request */
-    hmmc->Instance->DCTRL &= (uint32_t) ~((uint32_t)SDMMC_DCTRL_DMAEN);
+    hmmc->Instance->DCTRL &= (uint32_t)~((uint32_t)SDMMC_DCTRL_DMAEN);
 
     /* Abort the MMC DMA Tx Stream */
-    if (hmmc->hdmatx != NULL)
+    if(hmmc->hdmatx != NULL)
     {
-      if (HAL_DMA_Abort(hmmc->hdmatx) != HAL_OK)
+      if(HAL_DMA_Abort(hmmc->hdmatx) != HAL_OK)
       {
         hmmc->ErrorCode |= HAL_MMC_ERROR_DMA;
       }
     }
     /* Abort the MMC DMA Rx Stream */
-    if (hmmc->hdmarx != NULL)
+    if(hmmc->hdmarx != NULL)
     {
-      if (HAL_DMA_Abort(hmmc->hdmarx) != HAL_OK)
+      if(HAL_DMA_Abort(hmmc->hdmarx) != HAL_OK)
       {
         hmmc->ErrorCode |= HAL_MMC_ERROR_DMA;
       }
@@ -2483,11 +2491,11 @@ HAL_StatusTypeDef HAL_MMC_Abort(MMC_HandleTypeDef *hmmc)
   hmmc->Context = MMC_CONTEXT_NONE;
 
   CardState = HAL_MMC_GetCardState(hmmc);
-  if ((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
+  if((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
   {
     hmmc->ErrorCode = SDMMC_CmdStopTransfer(hmmc->Instance);
   }
-  if (hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
+  if(hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
   {
     return HAL_ERROR;
   }
@@ -2495,41 +2503,41 @@ HAL_StatusTypeDef HAL_MMC_Abort(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Abort the current transfer and disable the MMC (IT mode).
- * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
- *                the configuration information for MMC module.
- * @retval HAL status
- */
+  * @brief  Abort the current transfer and disable the MMC (IT mode).
+  * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
+  *                the configuration information for MMC module.
+  * @retval HAL status
+  */
 HAL_StatusTypeDef HAL_MMC_Abort_IT(MMC_HandleTypeDef *hmmc)
 {
   HAL_MMC_CardStateTypeDef CardState;
 
   /* DIsable All interrupts */
-  __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |
-                                 SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR);
+  __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT|\
+                           SDMMC_IT_TXUNDERR| SDMMC_IT_RXOVERR);
 
   /* Clear All flags */
   __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
 
-  if ((hmmc->hdmatx != NULL) || (hmmc->hdmarx != NULL))
+  if((hmmc->hdmatx != NULL) || (hmmc->hdmarx != NULL))
   {
     /* Disable the MMC DMA request */
-    hmmc->Instance->DCTRL &= (uint32_t) ~((uint32_t)SDMMC_DCTRL_DMAEN);
+    hmmc->Instance->DCTRL &= (uint32_t)~((uint32_t)SDMMC_DCTRL_DMAEN);
 
     /* Abort the MMC DMA Tx Stream */
-    if (hmmc->hdmatx != NULL)
+    if(hmmc->hdmatx != NULL)
     {
-      hmmc->hdmatx->XferAbortCallback = MMC_DMATxAbort;
-      if (HAL_DMA_Abort_IT(hmmc->hdmatx) != HAL_OK)
+      hmmc->hdmatx->XferAbortCallback =  MMC_DMATxAbort;
+      if(HAL_DMA_Abort_IT(hmmc->hdmatx) != HAL_OK)
       {
         hmmc->hdmatx = NULL;
       }
     }
     /* Abort the MMC DMA Rx Stream */
-    if (hmmc->hdmarx != NULL)
+    if(hmmc->hdmarx != NULL)
     {
-      hmmc->hdmarx->XferAbortCallback = MMC_DMARxAbort;
-      if (HAL_DMA_Abort_IT(hmmc->hdmarx) != HAL_OK)
+      hmmc->hdmarx->XferAbortCallback =  MMC_DMARxAbort;
+      if(HAL_DMA_Abort_IT(hmmc->hdmarx) != HAL_OK)
       {
         hmmc->hdmarx = NULL;
       }
@@ -2537,22 +2545,22 @@ HAL_StatusTypeDef HAL_MMC_Abort_IT(MMC_HandleTypeDef *hmmc)
   }
 
   /* No transfer ongoing on both DMA channels*/
-  if ((hmmc->hdmatx == NULL) && (hmmc->hdmarx == NULL))
+  if((hmmc->hdmatx == NULL) && (hmmc->hdmarx == NULL))
   {
     CardState = HAL_MMC_GetCardState(hmmc);
     hmmc->State = HAL_MMC_STATE_READY;
 
-    if ((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
+    if((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
     {
       hmmc->ErrorCode = SDMMC_CmdStopTransfer(hmmc->Instance);
     }
-    if (hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
+    if(hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
     {
       return HAL_ERROR;
     }
     else
     {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
       hmmc->AbortCpltCallback(hmmc);
 #else
       HAL_MMC_AbortCallback(hmmc);
@@ -2564,49 +2572,49 @@ HAL_StatusTypeDef HAL_MMC_Abort_IT(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @}
- */
+  * @}
+  */
 
 /**
- * @}
- */
+  * @}
+  */
 
 /* Private function ----------------------------------------------------------*/
 /** @addtogroup MMC_Private_Functions
- * @{
- */
+  * @{
+  */
 
 /**
- * @brief  DMA MMC transmit process complete callback
- * @param  hdma: DMA handle
- * @retval None
- */
+  * @brief  DMA MMC transmit process complete callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
 static void MMC_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 {
-  MMC_HandleTypeDef *hmmc = (MMC_HandleTypeDef *)(hdma->Parent);
+  MMC_HandleTypeDef* hmmc = (MMC_HandleTypeDef* )(hdma->Parent);
 
   /* Enable DATAEND Interrupt */
   __HAL_MMC_ENABLE_IT(hmmc, (SDMMC_IT_DATAEND));
 }
 
 /**
- * @brief  DMA MMC receive process complete callback
- * @param  hdma: DMA handle
- * @retval None
- */
+  * @brief  DMA MMC receive process complete callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
 static void MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  MMC_HandleTypeDef *hmmc = (MMC_HandleTypeDef *)(hdma->Parent);
+  MMC_HandleTypeDef* hmmc = (MMC_HandleTypeDef* )(hdma->Parent);
   uint32_t errorstate;
 
   /* Send stop command in multiblock write */
-  if (hmmc->Context == (MMC_CONTEXT_READ_MULTIPLE_BLOCK | MMC_CONTEXT_DMA))
+  if(hmmc->Context == (MMC_CONTEXT_READ_MULTIPLE_BLOCK | MMC_CONTEXT_DMA))
   {
     errorstate = SDMMC_CmdStopTransfer(hmmc->Instance);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       hmmc->ErrorCode |= errorstate;
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
       hmmc->ErrorCallback(hmmc);
 #else
       HAL_MMC_ErrorCallback(hmmc);
@@ -2616,14 +2624,14 @@ static void MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 
   /* Disable the DMA transfer for transmit request by setting the DMAEN bit
   in the MMC DCTRL register */
-  hmmc->Instance->DCTRL &= (uint32_t) ~((uint32_t)SDMMC_DCTRL_DMAEN);
+  hmmc->Instance->DCTRL &= (uint32_t)~((uint32_t)SDMMC_DCTRL_DMAEN);
 
   /* Clear all the static flags */
   __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_DATA_FLAGS);
 
   hmmc->State = HAL_MMC_STATE_READY;
 
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
   hmmc->RxCpltCallback(hmmc);
 #else
   HAL_MMC_RxCpltCallback(hmmc);
@@ -2631,41 +2639,41 @@ static void MMC_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 }
 
 /**
- * @brief  DMA MMC communication error callback
- * @param  hdma: DMA handle
- * @retval None
- */
+  * @brief  DMA MMC communication error callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
 static void MMC_DMAError(DMA_HandleTypeDef *hdma)
 {
-  MMC_HandleTypeDef *hmmc = (MMC_HandleTypeDef *)(hdma->Parent);
+  MMC_HandleTypeDef* hmmc = (MMC_HandleTypeDef* )(hdma->Parent);
   HAL_MMC_CardStateTypeDef CardState;
   uint32_t RxErrorCode, TxErrorCode;
 
   /* if DMA error is FIFO error ignore it */
-  if (HAL_DMA_GetError(hdma) != HAL_DMA_ERROR_FE)
+  if(HAL_DMA_GetError(hdma) != HAL_DMA_ERROR_FE)
   {
     RxErrorCode = hmmc->hdmarx->ErrorCode;
     TxErrorCode = hmmc->hdmatx->ErrorCode;
-    if ((RxErrorCode == HAL_DMA_ERROR_TE) || (TxErrorCode == HAL_DMA_ERROR_TE))
+    if((RxErrorCode == HAL_DMA_ERROR_TE) || (TxErrorCode == HAL_DMA_ERROR_TE))
     {
       /* Clear All flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
 
       /* Disable All interrupts */
-      __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT |
-                                     SDMMC_IT_TXUNDERR | SDMMC_IT_RXOVERR);
+      __HAL_MMC_DISABLE_IT(hmmc, SDMMC_IT_DATAEND | SDMMC_IT_DCRCFAIL | SDMMC_IT_DTIMEOUT|\
+        SDMMC_IT_TXUNDERR| SDMMC_IT_RXOVERR);
 
       hmmc->ErrorCode |= HAL_MMC_ERROR_DMA;
       CardState = HAL_MMC_GetCardState(hmmc);
-      if ((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
+      if((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
       {
         hmmc->ErrorCode |= SDMMC_CmdStopTransfer(hmmc->Instance);
       }
 
-      hmmc->State = HAL_MMC_STATE_READY;
+      hmmc->State= HAL_MMC_STATE_READY;
     }
 
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
     hmmc->ErrorCallback(hmmc);
 #else
     HAL_MMC_ErrorCallback(hmmc);
@@ -2674,33 +2682,33 @@ static void MMC_DMAError(DMA_HandleTypeDef *hdma)
 }
 
 /**
- * @brief  DMA MMC Tx Abort callback
- * @param  hdma: DMA handle
- * @retval None
- */
+  * @brief  DMA MMC Tx Abort callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
 static void MMC_DMATxAbort(DMA_HandleTypeDef *hdma)
 {
-  MMC_HandleTypeDef *hmmc = (MMC_HandleTypeDef *)(hdma->Parent);
+  MMC_HandleTypeDef* hmmc = (MMC_HandleTypeDef* )(hdma->Parent);
   HAL_MMC_CardStateTypeDef CardState;
 
-  if (hmmc->hdmatx != NULL)
+  if(hmmc->hdmatx != NULL)
   {
     hmmc->hdmatx = NULL;
   }
 
   /* All DMA channels are aborted */
-  if (hmmc->hdmarx == NULL)
+  if(hmmc->hdmarx == NULL)
   {
     CardState = HAL_MMC_GetCardState(hmmc);
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
     hmmc->State = HAL_MMC_STATE_READY;
-    if ((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
+    if((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
     {
       hmmc->ErrorCode |= SDMMC_CmdStopTransfer(hmmc->Instance);
 
-      if (hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
+      if(hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->AbortCpltCallback(hmmc);
 #else
         HAL_MMC_AbortCallback(hmmc);
@@ -2708,7 +2716,7 @@ static void MMC_DMATxAbort(DMA_HandleTypeDef *hdma)
       }
       else
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->ErrorCallback(hmmc);
 #else
         HAL_MMC_ErrorCallback(hmmc);
@@ -2719,33 +2727,33 @@ static void MMC_DMATxAbort(DMA_HandleTypeDef *hdma)
 }
 
 /**
- * @brief  DMA MMC Rx Abort callback
- * @param  hdma: DMA handle
- * @retval None
- */
+  * @brief  DMA MMC Rx Abort callback
+  * @param  hdma: DMA handle
+  * @retval None
+  */
 static void MMC_DMARxAbort(DMA_HandleTypeDef *hdma)
 {
-  MMC_HandleTypeDef *hmmc = (MMC_HandleTypeDef *)(hdma->Parent);
+  MMC_HandleTypeDef* hmmc = (MMC_HandleTypeDef* )(hdma->Parent);
   HAL_MMC_CardStateTypeDef CardState;
 
-  if (hmmc->hdmarx != NULL)
+  if(hmmc->hdmarx != NULL)
   {
     hmmc->hdmarx = NULL;
   }
 
   /* All DMA channels are aborted */
-  if (hmmc->hdmatx == NULL)
+  if(hmmc->hdmatx == NULL)
   {
     CardState = HAL_MMC_GetCardState(hmmc);
     hmmc->ErrorCode = HAL_MMC_ERROR_NONE;
     hmmc->State = HAL_MMC_STATE_READY;
-    if ((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
+    if((CardState == HAL_MMC_CARD_RECEIVING) || (CardState == HAL_MMC_CARD_SENDING))
     {
       hmmc->ErrorCode |= SDMMC_CmdStopTransfer(hmmc->Instance);
 
-      if (hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
+      if(hmmc->ErrorCode != HAL_MMC_ERROR_NONE)
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->AbortCpltCallback(hmmc);
 #else
         HAL_MMC_AbortCallback(hmmc);
@@ -2753,7 +2761,7 @@ static void MMC_DMARxAbort(DMA_HandleTypeDef *hdma)
       }
       else
       {
-#if defined(USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
+#if defined (USE_HAL_MMC_REGISTER_CALLBACKS) && (USE_HAL_MMC_REGISTER_CALLBACKS == 1U)
         hmmc->ErrorCallback(hmmc);
 #else
         HAL_MMC_ErrorCallback(hmmc);
@@ -2764,10 +2772,10 @@ static void MMC_DMARxAbort(DMA_HandleTypeDef *hdma)
 }
 
 /**
- * @brief  Initializes the mmc card.
- * @param  hmmc: Pointer to MMC handle
- * @retval MMC Card error state
- */
+  * @brief  Initializes the mmc card.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval MMC Card error state
+  */
 static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 {
   HAL_MMC_CardCSDTypeDef CSD;
@@ -2776,7 +2784,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
   MMC_InitTypeDef Init;
 
   /* Check the power State */
-  if (SDMMC_GetPowerState(hmmc->Instance) == 0U)
+  if(SDMMC_GetPowerState(hmmc->Instance) == 0U)
   {
     /* Power off */
     return HAL_MMC_ERROR_REQUEST_NOT_APPLICABLE;
@@ -2784,7 +2792,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Send CMD2 ALL_SEND_CID */
   errorstate = SDMMC_CmdSendCID(hmmc->Instance);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
@@ -2800,7 +2808,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
   /* Send CMD3 SET_REL_ADDR with RCA = 2 (should be greater than 1) */
   /* MMC Card publishes its RCA. */
   errorstate = SDMMC_CmdSetRelAddMmc(hmmc->Instance, mmc_rca);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
@@ -2810,7 +2818,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Send CMD9 SEND_CSD with argument as card's RCA */
   errorstate = SDMMC_CmdSendCSD(hmmc->Instance, (uint32_t)(hmmc->MmcCard.RelCardAdd << 16U));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
@@ -2828,7 +2836,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* Select the Card */
   errorstate = SDMMC_CmdSelDesel(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
@@ -2841,7 +2849,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
   errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->ErrorCode |= errorstate;
   }
@@ -2854,7 +2862,7 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 
   /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
   errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->ErrorCode |= errorstate;
   }
@@ -2869,12 +2877,12 @@ static uint32_t MMC_InitCard(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Enquires cards about their operating voltage and configures clock
- *         controls and stores MMC information that will be needed in future
- *         in the MMC handle.
- * @param  hmmc: Pointer to MMC handle
- * @retval error state
- */
+  * @brief  Enquires cards about their operating voltage and configures clock
+  *         controls and stores MMC information that will be needed in future
+  *         in the MMC handle.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval error state
+  */
 static uint32_t MMC_PowerON(MMC_HandleTypeDef *hmmc)
 {
   __IO uint32_t count = 0U;
@@ -2883,21 +2891,21 @@ static uint32_t MMC_PowerON(MMC_HandleTypeDef *hmmc)
 
   /* CMD0: GO_IDLE_STATE */
   errorstate = SDMMC_CmdGoIdleState(hmmc->Instance);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
 
-  while (validvoltage == 0U)
+  while(validvoltage == 0U)
   {
-    if (count++ == SDMMC_MAX_VOLT_TRIAL)
+    if(count++ == SDMMC_MAX_VOLT_TRIAL)
     {
       return HAL_MMC_ERROR_INVALID_VOLTRANGE;
     }
 
     /* SEND CMD1 APP_CMD with voltage range as argument */
     errorstate = SDMMC_CmdOpCondition(hmmc->Instance, MMC_VOLTAGE_RANGE);
-    if (errorstate != HAL_MMC_ERROR_NONE)
+    if(errorstate != HAL_MMC_ERROR_NONE)
     {
       return HAL_MMC_ERROR_UNSUPPORTED_FEATURE;
     }
@@ -2923,10 +2931,10 @@ static uint32_t MMC_PowerON(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Turns the SDMMC output signals off.
- * @param  hmmc: Pointer to MMC handle
- * @retval None
- */
+  * @brief  Turns the SDMMC output signals off.
+  * @param  hmmc: Pointer to MMC handle
+  * @retval None
+  */
 static void MMC_PowerOFF(MMC_HandleTypeDef *hmmc)
 {
   /* Set Power State to OFF */
@@ -2934,24 +2942,24 @@ static void MMC_PowerOFF(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Returns the current card's status.
- * @param  hmmc: Pointer to MMC handle
- * @param  pCardStatus: pointer to the buffer that will contain the MMC card
- *         status (Card Status register)
- * @retval error state
- */
+  * @brief  Returns the current card's status.
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pCardStatus: pointer to the buffer that will contain the MMC card
+  *         status (Card Status register)
+  * @retval error state
+  */
 static uint32_t MMC_SendStatus(MMC_HandleTypeDef *hmmc, uint32_t *pCardStatus)
 {
   uint32_t errorstate;
 
-  if (pCardStatus == NULL)
+  if(pCardStatus == NULL)
   {
     return HAL_MMC_ERROR_PARAM;
   }
 
   /* Send Status command */
   errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(hmmc->MmcCard.RelCardAdd << 16U));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     return errorstate;
   }
@@ -2963,13 +2971,13 @@ static uint32_t MMC_SendStatus(MMC_HandleTypeDef *hmmc, uint32_t *pCardStatus)
 }
 
 /**
- * @brief  Reads extended CSD register to get the sectors number of the device
- * @param  hmmc: Pointer to MMC handle
- * @param  pFieldData: Pointer to the read buffer
- * @param  FieldIndex: Index of the field to be read
- * @param  Timeout: Specify timeout value
- * @retval HAL status
- */
+  * @brief  Reads extended CSD register to get the sectors number of the device
+  * @param  hmmc: Pointer to MMC handle
+  * @param  pFieldData: Pointer to the read buffer
+  * @param  FieldIndex: Index of the field to be read
+  * @param  Timeout: Specify timeout value
+  * @retval HAL status
+  */
 static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, uint16_t FieldIndex, uint32_t Timeout)
 {
   SDMMC_DataInitTypeDef config;
@@ -2985,17 +2993,17 @@ static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, ui
   hmmc->Instance->DCTRL = 0;
 
   /* Configure the MMC DPSM (Data Path State Machine) */
-  config.DataTimeOut = SDMMC_DATATIMEOUT;
-  config.DataLength = 512;
+  config.DataTimeOut   = SDMMC_DATATIMEOUT;
+  config.DataLength    = 512;
   config.DataBlockSize = SDMMC_DATABLOCK_SIZE_512B;
-  config.TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC;
-  config.TransferMode = SDMMC_TRANSFER_MODE_BLOCK;
-  config.DPSM = SDMMC_DPSM_ENABLE;
+  config.TransferDir   = SDMMC_TRANSFER_DIR_TO_SDMMC;
+  config.TransferMode  = SDMMC_TRANSFER_MODE_BLOCK;
+  config.DPSM          = SDMMC_DPSM_ENABLE;
   (void)SDMMC_ConfigData(hmmc->Instance, &config);
 
   /* Set Block Size for Card */
   errorstate = SDMMC_CmdSendEXTCSD(hmmc->Instance, 0);
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     /* Clear all the static flags */
     __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
@@ -3005,17 +3013,17 @@ static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, ui
   }
 
   /* Poll on SDMMC flags */
-  while (!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
+  while(!__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXOVERR | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DATAEND))
   {
-    if (__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF))
+    if(__HAL_MMC_GET_FLAG(hmmc, SDMMC_FLAG_RXFIFOHF))
     {
       /* Read data from SDMMC Rx FIFO */
-      for (count = 0U; count < 8U; count++)
+      for(count = 0U; count < 8U; count++)
       {
         tmp_data = SDMMC_ReadFIFO(hmmc->Instance);
         /* eg : SEC_COUNT   : FieldIndex = 212 => i+count = 53 */
         /*      DEVICE_TYPE : FieldIndex = 196 => i+count = 49 */
-        if ((i + count) == ((uint32_t)FieldIndex / 4U))
+        if ((i + count) == ((uint32_t)FieldIndex/4U))
         {
           *pFieldData = tmp_data;
         }
@@ -3023,19 +3031,19 @@ static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, ui
       i += 8U;
     }
 
-    if (((HAL_GetTick() - tickstart) >= Timeout) || (Timeout == 0U))
+    if(((HAL_GetTick()-tickstart) >=  Timeout) || (Timeout == 0U))
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDMMC_STATIC_FLAGS);
       hmmc->ErrorCode |= HAL_MMC_ERROR_TIMEOUT;
-      hmmc->State = HAL_MMC_STATE_READY;
+      hmmc->State= HAL_MMC_STATE_READY;
       return HAL_TIMEOUT;
     }
   }
 
   /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
   errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16));
-  if (errorstate != HAL_MMC_ERROR_NONE)
+  if(errorstate != HAL_MMC_ERROR_NONE)
   {
     hmmc->ErrorCode |= errorstate;
   }
@@ -3049,15 +3057,15 @@ static uint32_t MMC_ReadExtCSD(MMC_HandleTypeDef *hmmc, uint32_t *pFieldData, ui
 }
 
 /**
- * @brief  Wrap up reading in non-blocking mode.
- * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
- *              the configuration information.
- * @retval None
- */
+  * @brief  Wrap up reading in non-blocking mode.
+  * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
+  *              the configuration information.
+  * @retval None
+  */
 static void MMC_Read_IT(MMC_HandleTypeDef *hmmc)
 {
   uint32_t count, data, dataremaining;
-  uint8_t *tmp;
+  uint8_t* tmp;
 
   tmp = hmmc->pRxBuffPtr;
   dataremaining = hmmc->RxXferSize;
@@ -3065,7 +3073,7 @@ static void MMC_Read_IT(MMC_HandleTypeDef *hmmc)
   if (dataremaining > 0U)
   {
     /* Read data from SDMMC Rx FIFO */
-    for (count = 0U; count < 8U; count++)
+    for(count = 0U; count < 8U; count++)
     {
       data = SDMMC_ReadFIFO(hmmc->Instance);
       *tmp = (uint8_t)(data & 0xFFU);
@@ -3088,15 +3096,15 @@ static void MMC_Read_IT(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Wrap up writing in non-blocking mode.
- * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
- *              the configuration information.
- * @retval None
- */
+  * @brief  Wrap up writing in non-blocking mode.
+  * @param  hmmc: pointer to a MMC_HandleTypeDef structure that contains
+  *              the configuration information.
+  * @retval None
+  */
 static void MMC_Write_IT(MMC_HandleTypeDef *hmmc)
 {
   uint32_t count, data, dataremaining;
-  uint8_t *tmp;
+  uint8_t* tmp;
 
   tmp = hmmc->pTxBuffPtr;
   dataremaining = hmmc->TxXferSize;
@@ -3104,7 +3112,7 @@ static void MMC_Write_IT(MMC_HandleTypeDef *hmmc)
   if (dataremaining > 0U)
   {
     /* Write data to SDMMC Tx FIFO */
-    for (count = 0U; count < 8U; count++)
+    for(count = 0U; count < 8U; count++)
     {
       data = (uint32_t)(*tmp);
       tmp++;
@@ -3127,12 +3135,12 @@ static void MMC_Write_IT(MMC_HandleTypeDef *hmmc)
 }
 
 /**
- * @brief  Update the power class of the device.
- * @param  hmmc MMC handle
- * @param  Wide Wide of MMC bus
- * @param  Speed Speed of the MMC bus
- * @retval MMC Card error state
- */
+  * @brief  Update the power class of the device.
+  * @param  hmmc MMC handle
+  * @param  Wide Wide of MMC bus
+  * @param  Speed Speed of the MMC bus
+  * @retval MMC Card error state
+  */
 static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
 {
   uint32_t count;
@@ -3140,12 +3148,12 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
   uint32_t errorstate = HAL_MMC_ERROR_NONE;
   uint32_t power_class, supported_pwr_class;
 
-  if ((Wide == SDMMC_BUS_WIDE_8B) || (Wide == SDMMC_BUS_WIDE_4B))
+  if((Wide == SDMMC_BUS_WIDE_8B) || (Wide == SDMMC_BUS_WIDE_4B))
   {
     power_class = 0U; /* Default value after power-on or software reset */
 
     /* Read the PowerClass field of the Extended CSD register */
-    if (MMC_ReadExtCSD(hmmc, &power_class, 187, SDMMC_DATATIMEOUT) != HAL_OK) /* Field POWER_CLASS [187] */
+    if(MMC_ReadExtCSD(hmmc, &power_class, 187, SDMMC_DATATIMEOUT) != HAL_OK) /* Field POWER_CLASS [187] */
     {
       errorstate = SDMMC_ERROR_GENERAL_UNKNOWN_ERR;
     }
@@ -3156,11 +3164,11 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
 
     /* Get the supported PowerClass field of the Extended CSD register */
     /* Field PWR_CL_26_xxx [201 or 203] */
-    supported_pwr_class = ((hmmc->Ext_CSD[(MMC_EXT_CSD_PWR_CL_26_INDEX / 4)] >> MMC_EXT_CSD_PWR_CL_26_POS) & 0x000000FFU);
+    supported_pwr_class = ((hmmc->Ext_CSD[(MMC_EXT_CSD_PWR_CL_26_INDEX/4)] >> MMC_EXT_CSD_PWR_CL_26_POS) & 0x000000FFU);
 
-    if (errorstate == HAL_MMC_ERROR_NONE)
+    if(errorstate == HAL_MMC_ERROR_NONE)
     {
-      if (Wide == SDMMC_BUS_WIDE_8B)
+      if(Wide == SDMMC_BUS_WIDE_8B)
       {
         /* Bit [7:4] : power class for 8-bits bus configuration - Bit [3:0] : power class for 4-bits bus configuration */
         supported_pwr_class = (supported_pwr_class >> 4U);
@@ -3171,14 +3179,14 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
         /* Need to change current power class */
         errorstate = SDMMC_CmdSwitch(hmmc->Instance, (0x03BB0000U | ((supported_pwr_class & 0x0FU) << 8U)));
 
-        if (errorstate == HAL_MMC_ERROR_NONE)
+        if(errorstate == HAL_MMC_ERROR_NONE)
         {
           /* While card is not ready for data and trial number for sending CMD13 is not exceeded */
           count = SDMMC_MAX_TRIAL;
           do
           {
             errorstate = SDMMC_CmdSendStatus(hmmc->Instance, (uint32_t)(((uint32_t)hmmc->MmcCard.RelCardAdd) << 16U));
-            if (errorstate != HAL_MMC_ERROR_NONE)
+            if(errorstate != HAL_MMC_ERROR_NONE)
             {
               break;
             }
@@ -3186,7 +3194,7 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
             /* Get command response */
             response = SDMMC_GetResponse(hmmc->Instance, SDMMC_RESP1);
             count--;
-          } while (((response & 0x100U) == 0U) && (count != 0U));
+          }while(((response & 0x100U) == 0U) && (count != 0U));
 
           /* Check the status after the switch command execution */
           if ((count != 0U) && (errorstate == HAL_MMC_ERROR_NONE))
@@ -3214,17 +3222,17 @@ static uint32_t MMC_PwrClassUpdate(MMC_HandleTypeDef *hmmc, uint32_t Wide)
 }
 
 /**
- * @}
- */
+  * @}
+  */
 
 #endif /* SDMMC1 */
 
 #endif /* HAL_MMC_MODULE_ENABLED */
 
 /**
- * @}
- */
+  * @}
+  */
 
 /**
- * @}
- */
+  * @}
+  */


### PR DESCRIPTION
This reworks an earlier commit that broke whitespace unnecessarily, and includes a minor improvement to the cache initialization to ensure that the cached extCSD is up to date. While this introduces no new functionality, it does mean that a log message during boot that was previously incorrect (claiming the cache was disabled) now prints the truth.