### PR TITLE
SCF-1264 Remove spin on systick from LL_RTC driver

### DIFF
--- a/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_rtc.c
+++ b/stm32cube/stm32f7xx/drivers/src/stm32f7xx_ll_rtc.c
@@ -736,17 +736,14 @@ ErrorStatus LL_RTC_EnterInitMode(RTC_TypeDef *RTCx)
 
     /* Wait till RTC is in INIT state and if Time out is reached exit */
     tmp = LL_RTC_IsActiveFlag_INIT(RTCx);
-    while ((timeout != 0U) && (tmp != 1U))
+    while (tmp != 1U)
     {
-      if (LL_SYSTICK_IsActiveCounterFlag() == 1U)
-      {
-        timeout --;
-      }
-      tmp = LL_RTC_IsActiveFlag_INIT(RTCx);
-      if (timeout == 0U)
+      if (--timeout == 0)
       {
         status = ERROR;
+        break;
       }
+      tmp = LL_RTC_IsActiveFlag_INIT(RTCx);
     }
   }
   return status;


### PR DESCRIPTION
The original code will only work if there is no other client of systick, since the bit being polled is cleared on read, and is handled in the systick ISR. So instead, simply poll the ready bit 1000 times (no longer 100ms) ... it is typically ready in very much less than that (300-400 polls).